### PR TITLE
Fix compiler warning about implicitly declared bitpop16

### DIFF
--- a/common/util.c
+++ b/common/util.c
@@ -30,6 +30,14 @@ uint8_t bitpop(uint8_t bits)
 */
 }
 
+uint16_t bitpop16(uint16_t bits)
+{
+	uint16_t c;
+	for (c = 0; bits; c++)
+		bits &= bits -1;
+	return c;
+}
+
 // most significant on-bit - return highest location of on-bit
 uint8_t biton(uint8_t bits)
 {

--- a/common/util.h
+++ b/common/util.h
@@ -29,6 +29,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
 uint8_t bitpop(uint8_t bits);
+uint16_t bitpop16(uint16_t bits);
 uint8_t biton(uint8_t bits);
 
 #endif


### PR DESCRIPTION
My matrix has more than 8 columns and I got a compiler warning about bitpop16 being implicitly declared. Here is a patch that seems to have fixed it. If you have a better way to implement it, feel free.
