### PR TITLE
Added FN_BITFIELD feature.

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Note that ***comment out*** to disable them.
     PS2_MOUSE_ENABLE = yes	# PS/2 mouse(TrackPoint) support
     EXTRAKEY_ENABLE = yes	# Enhanced feature for Windows(Audio control and System control)
     NKRO_ENABLE = yes		# USB Nkey Rollover
+	FN_BITFIELD = yes		# FN key states are bits into layer index
 
 ### 3. Programmer
 Set proper command for your controller, bootloader and programmer.

--- a/common.mk
+++ b/common.mk
@@ -37,5 +37,9 @@ ifdef $(or MOUSEKEY_ENABLE, PS2_MOUSE_ENABLE)
     OPT_DEFS += -DMOUSE_ENABLE
 endif
 
+ifdef FN_BITFIELD
+	OPT_DEFS += -DFN_BITFIELD
+endif
+
 # Search Path
 VPATH += $(TOP_DIR)/common

--- a/common/keyboard.c
+++ b/common/keyboard.c
@@ -127,7 +127,11 @@ static void layer_switch_on(uint8_t code)
 {
     if (!IS_FN(code)) return;
     fn_state_bits |= FN_BIT(code);
+#ifdef FN_BITFIELD
+    uint8_t new_layer = keymap_fn_layer(fn_state_bits & 7);
+#else
     uint8_t new_layer = (fn_state_bits ? keymap_fn_layer(biton(fn_state_bits)) : default_layer);
+#endif
     if (current_layer != new_layer) {
         Kdebug("Layer Switch(on): "); Kdebug_hex(current_layer);
         Kdebug(" -> "); Kdebug_hex(new_layer); Kdebug("\n");
@@ -141,7 +145,11 @@ static bool layer_switch_off(uint8_t code)
 {
     if (!IS_FN(code)) return false;
     fn_state_bits &= ~FN_BIT(code);
+#ifdef FN_BITFIELD
+    uint8_t new_layer = keymap_fn_layer(fn_state_bits & 7);
+#else
     uint8_t new_layer = (fn_state_bits ? keymap_fn_layer(biton(fn_state_bits)) : default_layer);
+#endif
     if (current_layer != new_layer) {
         Kdebug("Layer Switch(off): "); Kdebug_hex(current_layer);
         Kdebug(" -> "); Kdebug_hex(new_layer); Kdebug("\n");

--- a/keyboard/phantom/Makefile.pjrc
+++ b/keyboard/phantom/Makefile.pjrc
@@ -79,6 +79,7 @@ F_CPU = 16000000
 EXTRAKEY_ENABLE = yes	# Audio control and System control
 #NKRO_ENABLE = yes	# USB Nkey Rollover
 CONSOLE_ENABLE = yes    # Console for debug
+#FN_BITFIELD = yes
 
 
 # Search Path


### PR DESCRIPTION
Hi,
I added a feature to support using MX lock key states as bits into the FN layer index. For example, I have 3 MX lock key switches, and their combined states can select from up to 8 layers. This may be useful to others and is a small change, so I'm requesting a merge into the official tmk_keyboard.

Thanks,
mtl
