### PR TITLE
Added standard layouts for ANSI and ISO to hid_liber

### DIFF
--- a/keyboard/hid_liber/Makefile.lufa
+++ b/keyboard/hid_liber/Makefile.lufa
@@ -125,5 +125,14 @@ include $(TOP_DIR)/protocol/lufa.mk
 include $(TOP_DIR)/common.mk
 include $(TOP_DIR)/rules.mk
 
-custom: OPT_DEFS += -DKEYMAP_CUSTOM
+ansi: OPT_DEFS += -DLAYOUT_ANSI
+ansi: all
+
+iso: OPT_DEFS += -DLAYOUT_ISO
+iso: all
+
+custom: OPT_DEFS += -DLAYOUT_CUSTOM
 custom: all
+
+alaricljs: OPT_DEFS += -DLAYOUT_ALARICLJS
+alaricljs: all

--- a/keyboard/hid_liber/Makefile.pjrc
+++ b/keyboard/hid_liber/Makefile.pjrc
@@ -98,5 +98,14 @@ include $(TOP_DIR)/protocol/pjrc.mk
 include $(TOP_DIR)/common.mk
 include $(TOP_DIR)/rules.mk
 
-custom: OPT_DEFS += -DKEYMAP_CUSTOM
+ansi: OPT_DEFS += -DLAYOUT_ANSI
+ansi: all
+
+iso: OPT_DEFS += -DLAYOUT_ISO
+iso: all
+
+custom: OPT_DEFS += -DLAYOUT_CUSTOM
 custom: all
+
+alaricljs: OPT_DEFS += -DLAYOUT_ALARICLJS
+alaricljs: all

--- a/keyboard/hid_liber/README.md
+++ b/keyboard/hid_liber/README.md
@@ -1,0 +1,17 @@
+hid_liberation firmware
+======================
+DIY daughterboard for Filco Majestouch TKL developed by Geekhack and Deskthority communities.
+The PCB was engineered by bpiphany.
+
+## Wiki on Deskthority.net
+- [Instructions](http://deskthority.net/wiki/HID_Liberation_Device_-_Instructions)
+- [Assembly Instructions](http://deskthority.net/wiki/HID_Liberation_Device_-_DIY_Instructions)
+
+
+Build
+-----
+Move to this directory then just run `make` like:
+
+    $ make -f Makefile.[pjrc|lufa] [ansi|iso|custom|alaricljs]
+
+Use `Makefile.pjrc` if you want to use PJRC stack or use `Makefile.lufa` for LUFA stack.

--- a/keyboard/hid_liber/keymap.c
+++ b/keyboard/hid_liber/keymap.c
@@ -63,12 +63,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 }
 
 /*
- * Add custom layouts. If no custom layout is defined the default layout is used.
-*/
-#if defined(KEYMAP_CUSTOM)
-    #include "keymap_custom.h"
-#else
-/*
  * Tenkeyless keyboard default layout, ISO & ANSI (ISO is between Left Shift
  * and Z, and the ANSI \ key above Return/Enter is used for the additional ISO
  * switch in the ASD row next to enter.  Use NUBS as keycode for the first and
@@ -90,90 +84,20 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  * `-----------------------------------------------------------' `-----------'
  */
 
-
-static const uint8_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-/* Layer 0: Default Layer
- *
- * ANSI:
- *
- * ,---.   ,---------------. ,---------------. ,---------------. ,-----------.
- * |Esc|   |F1 |F2 |F3 |F4 | |F5 |F6 |F7 |F8 | |F9 |F10|F11|F12| |PrS|ScL|Pau|
- * `---'   `---------------' `---------------' `---------------' `-----------'
- * ,-----------------------------------------------------------. ,-----------.
- * |~  |  1|  2|  3|  4|  5|  6|  7|  8|  9|  0|  -|  =|Backsp | |Ins|Hom|PgU|
- * |-----------------------------------------------------------| |-----------|
- * |Tab  |  Q|  W|  E|  R|  T|  Y|  U|  I|  O|  P|  [|  ]|    \| |Del|End|PgD|
- * |-----------------------------------------------------------| `-----------'
- * |FN1   |  A|  S|  D|  F|  G|  H|  J|  K|  L|  ;|  '|Return  |              
- * |-----------------------------------------------------------|     ,---.    
- * |Shft|iso|  Z|  X|  C|  V|  B|  N|  M|  ,|  .|  /|Shift     |     |Up |    
- * |-----------------------------------------------------------| ,-----------.
- * |Ctl|Gui|Alt|          Space                |Alt|Gui|App|Ctl| |Lef|Dow|Rig|
- * `-----------------------------------------------------------' `-----------'
- */
-
-  KEYMAP(\
-    ESC,  F1,  F2,  F3,  F4,  F5,  F6,  F7,  F8,  F9, F10,  F11,  F12,       PSCR, SLCK,  BRK, \
-    GRV,   1,   2,   3,   4,   5,   6,   7,   8,   9,   0, MINS,  EQL, BSPC,  INS, HOME, PGUP, \
-    TAB,   Q,   W,   E,   R,   T,   Y,   U,   I,   O,   P, LBRC, RBRC, BSLS,  DEL,  END, PGDN, \
-    FN1,   A,   S,   D,   F,   G,   H,   J,   K,   L, SCLN, QUOT,       ENT,                   \
-    LSFT, NUBS, Z,   X,   C,   V,   B,   N,   M, COMM, DOT, SLSH,      RSFT,         UP,       \
-    LCTL, LGUI, LALT,             SPC,                RALT, RGUI, APP, RCTL, LEFT, DOWN, RGHT),
-
-/*  EXAMPLE ISO keymap, see the NUBS and NUHS keycodes 
- *  KEYMAP(\
- *    ESC, F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, PSCR, SLCK, BRK, \
- *    GRV, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, MINS, EQL, BSPC, INS, HOME, PGUP, \
- *    TAB, Q, W, E, R, T, Y, U, I, O, P, LBRC, RBRC, NUHS, DEL, END, PGDN, \
- *    CAPS, A, S, D, F, G, H, J, K, L, SCLN, QUOT, ENT, \
- *    LSFT, NUBS, Z, X, C, V, B, N, M, COMM, DOT, SLSH, RSFT, UP, \
- *    LCTL, FN1, LALT, SPC, RALT, RGUI, APP, RCTL, LEFT, DOWN, RGHT),
- */
-
-
-/*  
- * ,---.   ,---------------. ,---------------. ,---------------. ,-----------.
- * |Esc|   |F1 |F2 |F3 |F4 | |F5 |F6 |F7 |F8 | |F9 |F10|F11|F12| |PrS|ScL|Slp|
- * `---'   `---------------' `---------------' `---------------' `-----------'
- * ,-----------------------------------------------------------. ,-----------.
- * |~  |  1|  2|  3|  4|  5|  6|  7|  8|  9|Mut|V- |V+ |Backsp | |Ins|Hom|PgU|
- * |-----------------------------------------------------------| |-----------|
- * |Tab  |  Q|  W|  E|  R|  T|  Y|  U|  I|MSt|Ply|Prv|Nxt|Media| |Del|End|PgD|
- * |-----------------------------------------------------------| `-----------'
- * |FN1   |  A|  S|  D|  F|  G|  H|  J|  K|  L|  ;|  '|Return  |              
- * |-----------------------------------------------------------|     ,---.    
- * |Shft|iso|  Z|  X|Clc|  V|  B|  N|  M|  ,|  .|  /|Caps      |     |Up |    
- * |-----------------------------------------------------------| ,-----------.
- * |Ctl|Gui|Alt|          Space                |Alt|Gui|App|Ctl| |Lef|Dow|Rig|
- * `-----------------------------------------------------------' `-----------'
- */
-
- KEYMAP(\
-    ESC,  F1,  F2,  F3,  F4,  F5,  F6,  F7,  F8,  F9, F10,  F11,  F12,       PSCR, SLCK, SLEP, \
-    GRV,   1,   2,   3,   4,   5,   6,   7,   8,   9,MUTE, VOLD, VOLU, BSPC,  INS, HOME, PGUP, \
-    TAB,   Q,   W,   E,   R,   T,   Y,   U,   I,MSTP,MPLY, MPRV, MNXT, MSEL,  DEL,  END, PGDN, \
-    FN1,   A,   S,   D,   F,   G,   H,   J,   K,   L, SCLN, QUOT,       ENT,                   \
-    LSFT, NUBS, Z,   X,CALC,   V,   B,   N,   M, COMM, DOT, SLSH,      CAPS,         UP,       \
-    LCTL, LGUI, LALT,             SPC,                RALT, RGUI, APP, RCTL, LEFT, DOWN, RGHT),
-
-
-};
-
 /*
- * Fn action definition
- */
-static const uint16_t PROGMEM fn_actions[] = { 
-    [0] = ACTION_LAYER_MOMENTARY(0),
-    [1] = ACTION_LAYER_MOMENTARY(1),
-    [2] = ACTION_LAYER_MOMENTARY(2),
-    [3] = ACTION_LAYER_MOMENTARY(3),
-    [4] = ACTION_LAYER_MOMENTARY(4),
-    [5] = ACTION_LAYER_MOMENTARY(5),
-    [6] = ACTION_LAYER_MOMENTARY(6),
-    [7] = ACTION_LAYER_MOMENTARY(7),
-    [8] = ACTION_LAYER_MOMENTARY(8),
-};
-#endif 
+ * Add different layouts. If no layout is defined the default layout will be set to ANSI.
+*/
+#if defined(LAYOUT_CUSTOM)
+    #include "keymap_custom.h"
+#elif defined(LAYOUT_ALARICLJS)
+    #include "keymap_alaricljs.h"
+#elif defined(LAYOUT_ISO)
+    #include "keymap_iso.h"
+#elif defined(LAYOUT_ANSI)
+    #include "keymap_ansi.h"
+#else
+    #include "keymap_ansi.h"
+#endif
 
 #define KEYMAPS_SIZE    (sizeof(keymaps) / sizeof(keymaps[0]))
 #define FN_ACTIONS_SIZE (sizeof(fn_actions) / sizeof(fn_actions[0]))

--- a/keyboard/hid_liber/keymap_alaricljs.h
+++ b/keyboard/hid_liber/keymap_alaricljs.h
@@ -1,0 +1,61 @@
+// hid_liber alaricljs
+// this was the standard layout when hid_liber was merged into tmk's firmware
+
+static const uint8_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+/* Layer 0: Default ANSI
+ *
+ * ,---.   ,---------------. ,---------------. ,---------------. ,-----------.
+ * |Esc|   |F1 |F2 |F3 |F4 | |F5 |F6 |F7 |F8 | |F9 |F10|F11|F12| |PrS|ScL|Pau|
+ * `---'   `---------------' `---------------' `---------------' `-----------'
+ * ,-----------------------------------------------------------. ,-----------.
+ * |~  |  1|  2|  3|  4|  5|  6|  7|  8|  9|  0|  -|  =|Backsp | |Ins|Hom|PgU|
+ * |-----------------------------------------------------------| |-----------|
+ * |Tab  |  Q|  W|  E|  R|  T|  Y|  U|  I|  O|  P|  [|  ]|    \| |Del|End|PgD|
+ * |-----------------------------------------------------------| `-----------'
+ * |FN1   |  A|  S|  D|  F|  G|  H|  J|  K|  L|  ;|  '|Return  |              
+ * |-----------------------------------------------------------|     ,---.    
+ * |Shft|iso|  Z|  X|  C|  V|  B|  N|  M|  ,|  .|  /|Shift     |     |Up |    
+ * |-----------------------------------------------------------| ,-----------.
+ * |Ctl|Gui|Alt|          Space                |Alt|Gui|App|Ctl| |Lef|Dow|Rig|
+ * `-----------------------------------------------------------' `-----------'
+ */
+
+  KEYMAP(\
+    ESC,  F1,  F2,  F3,  F4,  F5,  F6,  F7,  F8,  F9, F10,  F11,  F12,       PSCR, SLCK,  BRK, \
+    GRV,   1,   2,   3,   4,   5,   6,   7,   8,   9,   0, MINS,  EQL, BSPC,  INS, HOME, PGUP, \
+    TAB,   Q,   W,   E,   R,   T,   Y,   U,   I,   O,   P, LBRC, RBRC, BSLS,  DEL,  END, PGDN, \
+    FN1,   A,   S,   D,   F,   G,   H,   J,   K,   L, SCLN, QUOT,       ENT,                   \
+    LSFT, NUBS, Z,   X,   C,   V,   B,   N,   M, COMM, DOT, SLSH,      RSFT,         UP,       \
+    LCTL, LGUI, LALT,             SPC,                RALT, RGUI, APP, RCTL, LEFT, DOWN, RGHT),
+
+/* Layer 1:
+ *
+ * ,---.   ,---------------. ,---------------. ,---------------. ,-----------.
+ * |Esc|   |F1 |F2 |F3 |F4 | |F5 |F6 |F7 |F8 | |F9 |F10|F11|F12| |PrS|ScL|Slp|
+ * `---'   `---------------' `---------------' `---------------' `-----------'
+ * ,-----------------------------------------------------------. ,-----------.
+ * |~  |  1|  2|  3|  4|  5|  6|  7|  8|  9|Mut|V- |V+ |Backsp | |Ins|Hom|PgU|
+ * |-----------------------------------------------------------| |-----------|
+ * |Tab  |  Q|  W|  E|  R|  T|  Y|  U|  I|MSt|Ply|Prv|Nxt|Media| |Del|End|PgD|
+ * |-----------------------------------------------------------| `-----------'
+ * |FN1   |  A|  S|  D|  F|  G|  H|  J|  K|  L|  ;|  '|Return  |              
+ * |-----------------------------------------------------------|     ,---.    
+ * |Shft|iso|  Z|  X|Clc|  V|  B|  N|  M|  ,|  .|  /|Caps      |     |Up |    
+ * |-----------------------------------------------------------| ,-----------.
+ * |Ctl|Gui|Alt|          Space                |Alt|Gui|App|Ctl| |Lef|Dow|Rig|
+ * `-----------------------------------------------------------' `-----------'
+ */
+
+ KEYMAP(\
+    ESC,  F1,  F2,  F3,  F4,  F5,  F6,  F7,  F8,  F9, F10,  F11,  F12,       PSCR, SLCK, SLEP, \
+    GRV,   1,   2,   3,   4,   5,   6,   7,   8,   9,MUTE, VOLD, VOLU, BSPC,  INS, HOME, PGUP, \
+    TAB,   Q,   W,   E,   R,   T,   Y,   U,   I,MSTP,MPLY, MPRV, MNXT, MSEL,  DEL,  END, PGDN, \
+    FN1,   A,   S,   D,   F,   G,   H,   J,   K,   L, SCLN, QUOT,       ENT,                   \
+    LSFT, NUBS, Z,   X,CALC,   V,   B,   N,   M, COMM, DOT, SLSH,      CAPS,         UP,       \
+    LCTL, LGUI, LALT,             SPC,                RALT, RGUI, APP, RCTL, LEFT, DOWN, RGHT),
+
+};
+
+static const uint16_t PROGMEM fn_actions[] = {
+	[1] = ACTION_LAYER_MOMENTARY(1),		// activate layer 1 when FN1 pressed
+};

--- a/keyboard/hid_liber/keymap_ansi.h
+++ b/keyboard/hid_liber/keymap_ansi.h
@@ -1,0 +1,32 @@
+// hid_liber ANSI
+
+static const uint8_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+/* Layer 0: Default ANSI
+ *
+ * ,---.   ,---------------. ,---------------. ,---------------. ,-----------.
+ * |Esc|   |F1 |F2 |F3 |F4 | |F5 |F6 |F7 |F8 | |F9 |F10|F11|F12| |PrS|ScL|Pau|
+ * `---'   `---------------' `---------------' `---------------' `-----------'
+ * ,-----------------------------------------------------------. ,-----------.
+ * |~  |  1|  2|  3|  4|  5|  6|  7|  8|  9|  0|  -|  =|Backsp | |Ins|Hom|PgU|
+ * |-----------------------------------------------------------| |-----------|
+ * |Tab  |  Q|  W|  E|  R|  T|  Y|  U|  I|  O|  P|  [|  ]|    \| |Del|End|PgD|
+ * |-----------------------------------------------------------| `-----------'
+ * |Caps  |  A|  S|  D|  F|  G|  H|  J|  K|  L|  ;|  '|Return  |              
+ * |-----------------------------------------------------------|     ,---.    
+ * |Shft|iso|  Z|  X|  C|  V|  B|  N|  M|  ,|  .|  /|Shift     |     |Up |    
+ * |-----------------------------------------------------------| ,-----------.
+ * |Ctl|Gui|Alt|          Space                |Alt|Gui|App|Ctl| |Lef|Dow|Rig|
+ * `-----------------------------------------------------------' `-----------'
+ */
+
+  KEYMAP(\
+      ESC,   F1,   F2,   F3,   F4,   F5,   F6,   F7,   F8,   F9,  F10,  F11,  F12,       PSCR, SLCK,  BRK, \
+      GRV,    1,    2,    3,    4,    5,    6,    7,    8,    9,    0, MINS,  EQL, BSPC,  INS, HOME, PGUP, \
+      TAB,    Q,    W,    E,    R,    T,    Y,    U,    I,    O,    P, LBRC, RBRC, BSLS,  DEL,  END, PGDN, \
+     CAPS,    A,    S,    D,    F,    G,    H,    J,    K,    L, SCLN, QUOT,        ENT,                   \
+     LSFT, NUBS,    Z,    X,    C,    V,    B,    N,    M, COMM,  DOT, SLSH,       RSFT,         UP,       \
+     LCTL, LGUI, LALT,              SPC,                         RALT, RGUI,  APP, RCTL, LEFT, DOWN, RGHT),
+
+};
+
+static const uint16_t PROGMEM fn_actions[] = {};

--- a/keyboard/hid_liber/keymap_custom.h
+++ b/keyboard/hid_liber/keymap_custom.h
@@ -1,7 +1,9 @@
+// hid_liber custom
+// ANSI layout with FN key instead of APP button
+// Layer 1 has mediakeys on the nav cluster and keypad numbers for alt-codes
+
 static const uint8_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-/* Keymap 0: Default Keymap
- *
- * ANSI:
+/* Layer 0: Default ANSI
  *
  * ,---.   ,---------------. ,---------------. ,---------------. ,-----------.
  * |Esc|   |F1 |F2 |F3 |F4 | |F5 |F6 |F7 |F8 | |F9 |F10|F11|F12| |PrS|ScL|Pau|
@@ -19,7 +21,7 @@ static const uint8_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * `-----------------------------------------------------------' `-----------'
  */
 
-  KEYMAP(
+  KEYMAP(\
       ESC,   F1,   F2,   F3,   F4,   F5,   F6,   F7,   F8,   F9,  F10,  F11,  F12,       PSCR, SLCK,  BRK, \
       GRV,    1,    2,    3,    4,    5,    6,    7,    8,    9,    0, MINS,  EQL, BSPC,  INS, HOME, PGUP, \
       TAB,    Q,    W,    E,    R,    T,    Y,    U,    I,    O,    P, LBRC, RBRC, BSLS,  DEL,  END, PGDN, \
@@ -28,7 +30,8 @@ static const uint8_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
      LCTL, LGUI, LALT,              SPC,                         RALT, RGUI,  FN1, RCTL, LEFT, DOWN, RGHT),
 
 /* 
- * Keymap 1: Media Keys
+ * Layer 1: Media Keys
+ *          Keypad numbers instead of normal numbers
  *
  * ,---.   ,---------------. ,---------------. ,---------------. ,-----------.
  * |Esc|   |F1 |F2 |F3 |F4 | |F5 |F6 |F7 |F8 | |F9 |F10|F11|F12| |PrS|ScL|Pau|
@@ -46,15 +49,16 @@ static const uint8_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  * `-----------------------------------------------------------' `-----------'
  */
 
- KEYMAP(
+ KEYMAP(\
      TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS,       TRNS, TRNS, TRNS, \
      TRNS,   P1,   P2,   P3,   P4,   P5,   P6,   P7,   P8,   P9,   P0, TRNS, TRNS, TRNS, TRNS, MSEL, VOLU, \
      TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, MUTE, VOLD, \
      TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS,       TRNS,                   \
      TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS,       TRNS,       MPLY,       \
      TRNS, TRNS, TRNS,                   TRNS,                   TRNS, TRNS,  FN1, TRNS, MPRV, MSTP, MNXT),
+
 };
 
 static const uint16_t PROGMEM fn_actions[] = {
-	[1] = ACTION_LAYER_MOMENTARY(1),		// activate Keymap 1 when FN1 pressed
+	[1] = ACTION_LAYER_MOMENTARY(1),		// activate layer 1 when FN1 pressed
 };

--- a/keyboard/hid_liber/keymap_iso.h
+++ b/keyboard/hid_liber/keymap_iso.h
@@ -1,0 +1,32 @@
+// hid_liber ISO
+
+static const uint8_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+/* Layer 0: Default ISO
+ *
+ * ,---.   ,---------------. ,---------------. ,---------------. ,-----------.
+ * |Esc|   |F1 |F2 |F3 |F4 | |F5 |F6 |F7 |F8 | |F9 |F10|F11|F12| |PrS|ScL|Pau|
+ * `---'   `---------------' `---------------' `---------------' `-----------'
+ * ,-----------------------------------------------------------. ,-----------.
+ * |~  |  1|  2|  3|  4|  5|  6|  7|  8|  9|  0|  -|  =|Backsp | |Ins|Hom|PgU|
+ * |-----------------------------------------------------------| |-----------|
+ * |Tab  |  Q|  W|  E|  R|  T|  Y|  U|  I|  O|  P|  [|  ]|    \| |Del|End|PgD|
+ * |-----------------------------------------------------------| `-----------'
+ * |Caps  |  A|  S|  D|  F|  G|  H|  J|  K|  L|  ;|  '|Return  |              
+ * |-----------------------------------------------------------|     ,---.    
+ * |Shft|iso|  Z|  X|  C|  V|  B|  N|  M|  ,|  .|  /|Shift     |     |Up |    
+ * |-----------------------------------------------------------| ,-----------.
+ * |Ctl|Gui|Alt|          Space                |Alt|Gui|App|Ctl| |Lef|Dow|Rig|
+ * `-----------------------------------------------------------' `-----------'
+ */
+
+  KEYMAP(\
+      ESC,   F1,   F2,   F3,   F4,   F5,   F6,   F7,   F8,   F9,  F10,  F11,  F12,       PSCR, SLCK,  BRK, \
+      GRV,    1,    2,    3,    4,    5,    6,    7,    8,    9,    0, MINS,  EQL, BSPC,  INS, HOME, PGUP, \
+      TAB,    Q,    W,    E,    R,    T,    Y,    U,    I,    O,    P, LBRC, RBRC, NUHS,  DEL,  END, PGDN, \
+     CAPS,    A,    S,    D,    F,    G,    H,    J,    K,    L, SCLN, QUOT,        ENT,                   \
+     LSFT, NUBS,    Z,    X,    C,    V,    B,    N,    M, COMM,  DOT, SLSH,       RSFT,         UP,       \
+     LCTL, LGUI, LALT,              SPC,                         RALT, RGUI,  APP, RCTL, LEFT, DOWN, RGHT),
+
+};
+
+static const uint16_t PROGMEM fn_actions[] = {};


### PR DESCRIPTION
After the confusion in this thread http://geekhack.org/index.php?topic=35065.msg949401#msg949401 I decided to add standard ANSI and ISO layouts and make ANSI the default. Moved the initial layout from alaricljs to a seperate one.

I have no ISO keyboard, so I'm not 100% sure that the ISO layout is right. I just copied the one which was commented out but I guess it should work. Feedback is appreciated.
