### PR TITLE
Add tap toggle modifiers

### DIFF
--- a/common/action.c
+++ b/common/action.c
@@ -128,6 +128,17 @@ void process_action(keyrecord_t *record)
                         }
                         break;
     #endif
+                    case MODS_TAP_TOGGLE:
+                        if (event.pressed) {
+                            if (tap_count <= TAPPING_TOGGLE) {
+                                register_mods(mods);
+                            }
+                        } else {
+                            if (tap_count < TAPPING_TOGGLE) {
+                                unregister_mods(mods);
+                            }
+                        }
+                        break;
                     default:
                         if (event.pressed) {
                             if (tap_count > 0) {

--- a/common/action_code.h
+++ b/common/action_code.h
@@ -34,6 +34,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  * ACT_MODS_TAP(001r):
  * 001r|mods|0000 0000    Modifiers with OneShot
+ * 001r|mods|0000 0001    Modifiers with tap toggle
  * 001r|mods|0000 00xx    (reserved)
  * 001r|mods| keycode     Modifiers with Tap Key(Dual role)
  *
@@ -205,12 +206,14 @@ enum mods_bit {
 };
 enum mods_codes {
     MODS_ONESHOT = 0x00,
+    MODS_TAP_TOGGLE = 0x01,
 };
 #define ACTION_KEY(key)                 ACTION(ACT_MODS, (key))
 #define ACTION_MODS(mods)               ACTION(ACT_MODS, (mods&0x1f)<<8 | 0)
 #define ACTION_MODS_KEY(mods, key)      ACTION(ACT_MODS, (mods&0x1f)<<8 | (key))
 #define ACTION_MODS_TAP_KEY(mods, key)  ACTION(ACT_MODS_TAP, (mods&0x1f)<<8 | (key))
 #define ACTION_MODS_ONESHOT(mods)       ACTION(ACT_MODS_TAP, (mods&0x1f)<<8 | MODS_ONESHOT)
+#define ACTION_MODS_TAP_TOGGLE(mods)    ACTION(ACT_MODS_TAP, (mods&0x1f)<<8 | MODS_TAP_TOGGLE)
 
 
 /*

--- a/doc/keymap.md
+++ b/doc/keymap.md
@@ -526,6 +526,12 @@ Say you want to type 'The', you have to push and hold Shift key before type 't' 
 Oneshot effect is cancel unless following key is pressed down within `ONESHOT_TIMEOUT` of `config.h`. No timeout when it is `0` or not defined.
 
 
+### 4.4 Tap Toggle Mods
+Similar to layer tap toggle, this works as a momentary modifier when holding, but toggles on with several taps. A single tap will 'unstick' the modifier again.
+
+    ACTION_MODS_TAP_TOGGLE(MOD_LSFT)
+
+
 
 
 ## 5. Legacy Keymap


### PR DESCRIPTION
Added a tap/toggle modifier action to the available action types. Includes documentation.

This is essentially like Windows' sticky keys, where a few repeated taps will trigger the modifier on, and it will stay on until another tap.
