### PR TITLE
Fixing a typo

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -40,7 +40,7 @@ Move to project directory in the firmware source.
 Build firmware using GNU `make` command. You'll see `<project>_<variant>.hex` file in that directory unless something unexpected occurs in build process.
 
 
-    mkae -f Makefile.<variant> clean
+    make -f Makefile.<variant> clean
     make -f Makefile.<variant>
 
 


### PR DESCRIPTION
On the build.md file, there's written "mkae" instead of "make"
