### PR TITLE
Fixing typo

### DIFF
--- a/converter/ps2_usb/README.md
+++ b/converter/ps2_usb/README.md
@@ -12,7 +12,7 @@ In case of Teensy2.0(ATMega32U4):
     - **Interrupt**:   **Clock** is on `PD1` and **Data** on `PD0`.(Recommended. Soarer's converter compatible)
     - **Busywait**:    **Clock** is on `PD1` and **Data** on `PD0`.
     - **USART**:       **Clock** is on `PD5` and **Data** on `PD2`.
-3. Optionally you need pull-up register. 1K-10K Ohm is OK.
+3. Optionally you need pull-up resistor. 1K-10K Ohm is OK.
 
 To change pin configuration edit config.h.
 


### PR DESCRIPTION
Replaced "register" with "resistor".
