### PR TITLE
Added support for bpiphany's Kitten Paw controller

### DIFF
--- a/keyboard/kitten_paw/Makefile.lufa
+++ b/keyboard/kitten_paw/Makefile.lufa
@@ -1,0 +1,117 @@
+#----------------------------------------------------------------------------
+# On command line:
+#
+# make all = Make software.
+#
+# make clean = Clean out built project files.
+#
+# make coff = Convert ELF to AVR COFF.
+#
+# make extcoff = Convert ELF to AVR Extended COFF.
+#
+# make program = Download the hex file to the device.
+#                Please customize your programmer settings(PROGRAM_CMD)
+#
+# make teensy = Download the hex file to the device, using teensy_loader_cli.
+#               (must have teensy_loader_cli installed).
+#
+# make dfu = Download the hex file to the device, using dfu-programmer (must
+#            have dfu-programmer installed).
+#
+# make flip = Download the hex file to the device, using Atmel FLIP (must
+#             have Atmel FLIP installed).
+#
+# make dfu-ee = Download the eeprom file to the device, using dfu-programmer
+#               (must have dfu-programmer installed).
+#
+# make flip-ee = Download the eeprom file to the device, using Atmel FLIP
+#                (must have Atmel FLIP installed).
+#
+# make debug = Start either simulavr or avarice as specified for debugging, 
+#              with avr-gdb or avr-insight as the front end for debugging.
+#
+# make filename.s = Just compile filename.c into the assembler code only.
+#
+# make filename.i = Create a preprocessed source file for use in submitting
+#                   bug reports to the GCC project.
+#
+# To rebuild project do "make clean" then "make all".
+#----------------------------------------------------------------------------
+
+# Target file name (without extension).
+TARGET = kittenpaw_lufa
+
+# Directory common source filess exist
+TOP_DIR = ../..
+
+# Directory keyboard dependent files exist
+TARGET_DIR = .
+
+# List C source files here. (C dependencies are automatically generated.)
+SRC =	keymap.c \
+	matrix.c \
+	led.c
+
+CONFIG_H = config.h
+
+# MCU name
+MCU = atmega32u2
+
+# Processor frequency.
+#     This will define a symbol, F_CPU, in all source code files equal to the
+#     processor frequency in Hz. You can then use this symbol in your source code to
+#     calculate timings. Do NOT tack on a 'UL' at the end, this will be done
+#     automatically to create a 32-bit value in your source code.
+#
+#     This will be an integer division of F_USB below, as it is sourced by
+#     F_USB after it has run through any CPU prescalers. Note that this value
+#     does not *change* the processor frequency - it should merely be updated to
+#     reflect the processor speed set externally so that the code can use accurate
+#     software delays.
+F_CPU = 16000000
+
+#
+# LUFA specific
+#
+# Target architecture (see library "Board Types" documentation).
+ARCH = AVR8
+
+# Input clock frequency.
+#     This will define a symbol, F_USB, in all source code files equal to the
+#     input clock frequency (before any prescaling is performed) in Hz. This value may
+#     differ from F_CPU if prescaling is used on the latter, and is required as the
+#     raw input clock is fed directly to the PLL sections of the AVR for high speed
+#     clock generation for the USB and other AVR subsections. Do NOT tack on a 'UL'
+#     at the end, this will be done automatically to create a 32-bit value in your
+#     source code.
+#
+#     If no clock division is performed on the input clock inside the AVR (via the
+#     CPU clock adjust registers or the clock division fuses), this will be equal to F_CPU.
+F_USB = $(F_CPU)
+
+
+# Build Options
+#   comment out to disable the options.
+#
+#BOOTMAGIC_ENABLE = yes	# Virtual DIP switch configuration(+1000)
+MOUSEKEY_ENABLE = yes	# Mouse keys(+4700)
+EXTRAKEY_ENABLE = yes	# Audio control and System control(+450)
+#CONSOLE_ENABLE = yes	# Console for debug(+400)
+COMMAND_ENABLE = yes    # Commands for debug and configuration
+#SLEEP_LED_ENABLE = yes  # Breathing sleep LED during USB suspend
+#NKRO_ENABLE = yes	# USB Nkey Rollover - not yet supported in LUFA
+
+
+# Boot Section Size in bytes
+#   Teensy halfKay   512
+#   Atmel DFU loader 4096
+#   LUFA bootloader  4096
+OPT_DEFS += -DBOOTLOADER_SIZE=4096
+
+# Search Path
+VPATH += $(TARGET_DIR)
+VPATH += $(TOP_DIR)
+
+include $(TOP_DIR)/protocol/lufa.mk
+include $(TOP_DIR)/common.mk
+include $(TOP_DIR)/rules.mk

--- a/keyboard/kitten_paw/README.md
+++ b/keyboard/kitten_paw/README.md
@@ -1,0 +1,20 @@
+Kitten Paw controller firmware
+======================
+Custom controller for the Costar Majestouch keyboard designed by bpiphany.
+
+*Note that this is not the official firmware*
+
+Build
+-----
+Move to this directory then just run `make` like:
+
+    $ make -f Makefile.lufa
+
+At the moment only the LUFA stack is supported.
+
+
+Bootloader
+---------
+To enter bootloader by hardware use a magnet above the controller before connecting the usb cable.
+
+It is still possible to use Boot Magic and Command (LSFT+RSFT+PAUS) to access the bootloader though.

--- a/keyboard/kitten_paw/config.h
+++ b/keyboard/kitten_paw/config.h
@@ -1,0 +1,43 @@
+/*
+Copyright 2014 Ralf Schmitt <ralf@bunkertor.net>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef CONFIG_H
+#define CONFIG_H
+
+/* USB Device descriptor parameter */
+#define VENDOR_ID       0xFEED
+#define PRODUCT_ID      0x6050
+#define DEVICE_VER      0x0104
+#define MANUFACTURER    Costar
+#define PRODUCT         Majestouch
+
+/* message strings */
+#define DESCRIPTION     t.m.k. keyboard firmware for Majestouch
+
+/* matrix size */
+#define MATRIX_ROWS 8
+#define MATRIX_COLS 18
+
+/* Set 0 if need no debouncing */
+#define DEBOUNCE    5
+
+/* key combination for command */
+#define IS_COMMAND() ( \
+    keyboard_report->mods == (MOD_BIT(KC_LSHIFT) | MOD_BIT(KC_RSHIFT)) \
+)
+
+#endif

--- a/keyboard/kitten_paw/keymap.c
+++ b/keyboard/kitten_paw/keymap.c
@@ -1,0 +1,102 @@
+/*
+Copyright 2014 Ralf Schmitt <ralf@bunkertor.net>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <avr/pgmspace.h>
+#include "keycode.h"
+#include "action.h"
+#include "action_macro.h"
+#include "report.h"
+#include "host.h"
+#include "debug.h"
+#include "keymap.h"
+
+/*
+ Matrix col/row mapping
+
+ ,----.    ,-------------------. ,-------------------. ,-------------------. ,--------------.
+ |06/6|    |07/4|08/4|08/2|08/6| |15/5|11/6|12/2|12/4| |14/4|14/5|14/6|14/0| |13/5|13/7|15/7|
+ `----'    `-------------------' `-------------------' `-------------------' `--------------'
+ ,-------------------------------------------------------------------------. ,--------------. ,-------------------.
+ |06/4|06/5|07/5|08/5|09/5|09/4|10/4|10/5|11/5|12/5|05/5|05/4|11/4|    14/2| |17/4|02/4|04/4| |16/1|17/1|04/1|04/0|
+ |-------------------------------------------------------------------------| |--------------| |-------------------|
+ |06/2  |06/7|07/7|08/7|09/7|09/2|10/2|10/7|11/7|12/7|05/7|05/2|11/2|  14/3| |16/4|02/5|04/5| |16/7|17/7|04/7|    |
+ |-------------------------------------------------------------------------| '--------------' |-------------- 02/7|
+ |02/7   |06/3|07/3|08/3|09/3|09/6|10/6|10/3|11/3|12/3|05/3|05/6|      14/1|                  |16/2|17/2|04/2|    |
+ |-------------------------------------------------------------------------|      ,----.      |-------------------|
+ |01/2     |06/1|07/1|08/1|09/1|09/0|10/0|10/1|11/1|12/1|05/0|         01/3|      |02/6|      |16/3|17/3|04/3|    |
+ |-------------------------------------------------------------------------| ,--------------. |-------------- 02/3|
+ |15/4|03/2|13/6|                 16/6                  |13/0|0/3|12/0|15/1| |02/0|16/0|17/0| | 17/6    |04/6|    |
+ `-------------------------------------------------------------------------' `--------------' `-------------------'
+*/
+
+#define KEYMAP( \
+    KG6,      KH4, KI4, KI2, KI6, KP5, KL6, KM2, KM4, KO4, KO5, KO6, KO0,   KN5, KN7, KP7,                       \
+    KG4, KG5, KH5, KI5, KJ5, KJ4, KK4, KK5, KL5, KM5, KF5, KF4, KL4, KO2,   KR4, KC4, KE4,   KQ1, KR1, KE1, KE0, \
+    KG2, KG7, KH7, KI7, KJ7, KJ2, KK2, KK7, KL7, KM7, KF7, KF2, KL2, KO3,   KQ4, KC5, KE5,   KQ7, KR7, KE7, KC7, \
+    KH2, KG3, KH3, KI3, KJ3, KJ6, KK6, KK3, KL3, KM3, KF3, KF6,      KO1,                    KQ2, KR2, KE2,      \
+    KB2, KH6, KG1, KH1, KI1, KJ1, KJ0, KK0, KK1, KL1, KM1, KF0,      KB3,        KC6,        KQ3, KR3, KE3, KC3, \
+    KP4, KD2, KN6,                KQ6,                KN0, KA3, KM0, KP1,   KC0, KQ0, KR0,   KR6,      KE6       \
+) { \
+/*            0         1         2         3         4         5         6         7   */  \
+/* A  0 */ {KC_NO,    KC_NO,    KC_NO,    KC_##KA3, KC_NO,    KC_NO,    KC_NO,    KC_NO   },\
+/* B  1 */ {KC_NO,    KC_NO,    KC_##KB2, KC_##KB3, KC_NO,    KC_NO,    KC_NO,    KC_NO   },\
+/* C  2 */ {KC_##KC0, KC_NO,    KC_NO,    KC_##KC3, KC_##KC4, KC_##KC5, KC_##KC6, KC_##KC7},\
+/* D  3 */ {KC_NO,    KC_NO,    KC_##KD2, KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO   },\
+/* E  4 */ {KC_##KE0, KC_##KE1, KC_##KE2, KC_##KE3, KC_##KE4, KC_##KE5, KC_##KE6, KC_##KE7},\
+/* F  5 */ {KC_##KF0, KC_NO,    KC_##KF2, KC_##KF3, KC_##KF4, KC_##KF5, KC_##KF6, KC_##KF7},\
+/* G  6 */ {KC_NO,    KC_##KG1, KC_##KG2, KC_##KG3, KC_##KG4, KC_##KG5, KC_##KG6, KC_##KG7},\
+/* H  7 */ {KC_NO,    KC_##KH1, KC_##KH2, KC_##KH3, KC_##KH4, KC_##KH5, KC_##KH6, KC_##KH7},\
+/* I  8 */ {KC_NO,    KC_##KI1, KC_##KI2, KC_##KI3, KC_##KI4, KC_##KI5, KC_##KI6, KC_##KI7},\
+/* J  9 */ {KC_##KJ0, KC_##KJ1, KC_##KJ2, KC_##KJ3, KC_##KJ4, KC_##KJ5, KC_##KJ6, KC_##KJ7},\
+/* K 10 */ {KC_##KK0, KC_##KK1, KC_##KK2, KC_##KK3, KC_##KK4, KC_##KK5, KC_##KK6, KC_##KK7},\
+/* L 11 */ {KC_NO,    KC_##KL1, KC_##KL2, KC_##KL3, KC_##KL4, KC_##KL5, KC_##KL6, KC_##KL7},\
+/* M 12 */ {KC_##KM0, KC_##KM1, KC_##KM2, KC_##KM3, KC_##KM4, KC_##KM5, KC_NO,    KC_##KM7},\
+/* N 13 */ {KC_##KN0, KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_##KN5, KC_##KN6, KC_##KN7},\
+/* O 14 */ {KC_##KO0, KC_##KO1, KC_##KO2, KC_##KO3, KC_##KO4, KC_##KO5, KC_##KO6, KC_NO   },\
+/* P 15 */ {KC_NO,    KC_##KP1, KC_NO,    KC_NO,    KC_##KP4, KC_##KP5, KC_NO,    KC_##KP7},\
+/* Q 16 */ {KC_##KQ0, KC_##KQ1, KC_##KQ2, KC_##KQ3, KC_##KQ4, KC_NO,    KC_##KQ6, KC_##KQ7},\
+/* R 17 */ {KC_##KR0, KC_##KR1, KC_##KR2, KC_##KR3, KC_##KR4, KC_NO,    KC_##KR6, KC_##KR7} \
+}
+
+#include "keymap_ansi.h"
+
+#define KEYMAPS_SIZE    (sizeof(keymaps) / sizeof(keymaps[0]))
+#define FN_ACTIONS_SIZE (sizeof(fn_actions) / sizeof(fn_actions[0]))
+
+/* translates key to keycode */
+uint8_t keymap_key_to_keycode(uint8_t layer, key_t key)
+{
+    if (layer < KEYMAPS_SIZE) {
+        return pgm_read_byte(&keymaps[(layer)][(key.col)][(key.row)]);
+    } else {
+        return pgm_read_byte(&keymaps[0][(key.col)][(key.row)]);
+    }
+}
+
+/* translates Fn keycode to action */
+action_t keymap_fn_to_action(uint8_t keycode)
+{
+    action_t action;
+    if (FN_INDEX(keycode) < FN_ACTIONS_SIZE) {
+        action.code = pgm_read_word(&fn_actions[FN_INDEX(keycode)]);
+    } else {
+        action.code = ACTION_NO;
+    }
+    return action;
+}

--- a/keyboard/kitten_paw/keymap_ansi.h
+++ b/keyboard/kitten_paw/keymap_ansi.h
@@ -1,0 +1,23 @@
+
+static const uint8_t PROGMEM keymaps[][MATRIX_COLS][MATRIX_ROWS] = {
+    /* Layer 0: Standard ANSI layer */
+    KEYMAP(\
+         ESC, F1,  F2,  F3,  F4,  F5,  F6,  F7,  F8,  F9,  F10, F11,  F12,        PSCR,SLCK,PAUS,                         \
+         GRV, 1,   2,   3,   4,   5,   6,   7,   8,   9,   0,   MINS, EQL,BSPC,   INS, HOME,PGUP,    NLCK,PSLS,PAST,PMNS, \
+         TAB, Q,   W,   E,   R,   T,   Y,   U,   I,   O,   P,   LBRC,RBRC,BSLS,   DEL, END, PGDN,    P7,  P8,  P9,  PPLS, \
+         CAPS,A,   S,   D,   F,   G,   H,   J,   K,   L,   SCLN,QUOT,      ENT,                      P4,  P5,  P6,        \
+         LSFT,NUBS,Z,   X,   C,   V,   B,   N,   M,   COMM,DOT, SLSH,     RSFT,        UP,           P1,  P2,  P3,  PENT, \
+         LCTL,LGUI,LALT,               SPC,                RALT,RGUI, FN0,RCTL,   LEFT,DOWN,RGHT,    P0,  PDOT),          \
+    /* Layer 1: Function layer */
+    KEYMAP(\
+         CALC,MYCM,WSCH,WHOM,MAIL,VOLD,VOLU,MSEL,MSTP,MPLY,MPRV,MNXT,TRNS,        WAKE, PWR,SLEP,                         \
+         TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,   TRNS,TRNS,TRNS,    TRNS,TRNS,TRNS,TRNS, \
+         TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,   TRNS,TRNS,TRNS,    TRNS,TRNS,TRNS,TRNS, \
+         TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,     TRNS,                      TRNS,TRNS,TRNS,      \
+         TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,     TRNS,        TRNS,         TRNS,TRNS,TRNS,TRNS, \
+         TRNS,TRNS,TRNS,               TRNS,               TRNS,TRNS,TRNS,TRNS,   TRNS,TRNS,TRNS,    TRNS,TRNS)
+};
+
+static const uint16_t PROGMEM fn_actions[] = {
+    [0] = ACTION_LAYER_MOMENTARY(1)
+};

--- a/keyboard/kitten_paw/led.c
+++ b/keyboard/kitten_paw/led.c
@@ -1,0 +1,60 @@
+/*
+Copyright 2014 Ralf Schmitt <ralf@bunkertor.net>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <avr/io.h>
+#include "stdint.h"
+#include "led.h"
+
+/* LED pin configuration
+ *
+ * Scroll Lock  PB7
+ * CAPS         PC6
+ * NUMLOCK      PC5
+ *
+ */
+void led_set(uint8_t usb_led)
+{
+    DDRB |= (1<<7);
+    DDRC |= (1<<5) | (1<<6);
+
+    if (usb_led & (1<<USB_LED_CAPS_LOCK))
+    {
+        PORTC &= ~(1<<6);
+    }
+    else
+    {
+        PORTC |= (1<<6);
+    }
+
+    if (usb_led & (1<<USB_LED_NUM_LOCK))
+    {
+        PORTC &= ~(1<<5);
+    }
+    else
+    {
+        PORTC |= (1<<5);
+    }
+
+    if (usb_led & (1<<USB_LED_SCROLL_LOCK))
+    {
+        PORTB &= ~(1<<7);
+    }
+    else
+    {
+        PORTB |= (1<<7);
+    }
+}

--- a/keyboard/kitten_paw/matrix.c
+++ b/keyboard/kitten_paw/matrix.c
@@ -1,0 +1,239 @@
+/*
+Copyright 2014 Ralf Schmitt <ralf@bunkertor.net>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <avr/io.h>
+#include <util/delay.h>
+#include "print.h"
+#include "debug.h"
+#include "util.h"
+#include "matrix.h"
+
+#ifndef DEBOUNCE
+#   define DEBOUNCE 0
+#endif
+static uint8_t debouncing = DEBOUNCE;
+
+static matrix_row_t matrix[MATRIX_ROWS];
+static matrix_row_t matrix_debouncing[MATRIX_ROWS];
+
+static uint8_t read_rows(void);
+static void init_rows(void);
+static void unselect_cols(void);
+static void select_col(uint8_t col);
+
+inline uint8_t matrix_rows(void)
+{
+    return MATRIX_ROWS;
+}
+
+inline uint8_t matrix_cols(void)
+{
+    return MATRIX_COLS;
+}
+
+void matrix_init(void)
+{
+    unselect_cols();
+    init_rows();
+    for (uint8_t i=0; i < MATRIX_ROWS; i++)  {
+        matrix[i] = 0;
+        matrix_debouncing[i] = 0;
+    }
+}
+
+uint8_t matrix_scan(void)
+{
+    for (uint8_t col = 0; col < MATRIX_COLS; col++) {
+        select_col(col);
+        _delay_us(3);
+        uint8_t rows = read_rows();
+        for (uint8_t row = 0; row < MATRIX_ROWS; row++) {
+            bool prev_bit = matrix_debouncing[row] & ((matrix_row_t)1<<col);
+            bool curr_bit = rows & (1<<row);
+            if (prev_bit != curr_bit) {
+                matrix_debouncing[row] ^= ((matrix_row_t)1<<col);
+                debouncing = DEBOUNCE;
+            }
+        }
+        unselect_cols();
+    }
+
+    if (debouncing) {
+        if (--debouncing) {
+            _delay_ms(1);
+        } else {
+            for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
+                matrix[i] = matrix_debouncing[i];
+            }
+        }
+    }
+
+    return 1;
+}
+
+bool matrix_is_modified(void)
+{
+    if (debouncing) return false;
+    return true;
+}
+
+inline bool matrix_is_on(uint8_t row, uint8_t col)
+{
+    return (matrix[row] & ((matrix_row_t)1<<col));
+}
+
+inline matrix_row_t matrix_get_row(uint8_t row)
+{
+    return matrix[row];
+}
+
+void matrix_print(void)
+{
+    print("\nr/c 0123456789ABCDEF\n");
+    for (uint8_t row = 0; row < MATRIX_ROWS; row++) {
+        xprintf("%02X: %032lb\n", row, bitrev32(matrix_get_row(row)));
+    }
+}
+
+uint8_t matrix_key_count(void)
+{
+    uint8_t count = 0;
+    for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
+        count += bitpop32(matrix[i]);
+    }
+    return count;
+}
+
+/* Row pin configuration
+ *
+ * row: 0    1    2    3    4    5    6    7
+ * pin: PC2  PB1  PB2  PB3  PC7  PB4  PB5  PB6
+ *
+ */
+static void init_rows(void)
+{
+    DDRC &= ~0b10000100;
+    DDRB &= ~0b01111110;
+    PORTC |= 0b10000100;
+    PORTB |= 0b01111110;
+}
+
+static uint8_t read_rows(void)
+{
+    return (PINC&(1<<2) ? 0 : (1<<0)) |
+           (PINB&(1<<1) ? 0 : (1<<1)) |
+           (PINB&(1<<2) ? 0 : (1<<2)) |
+           (PINB&(1<<3) ? 0 : (1<<3)) |
+           (PINC&(1<<7) ? 0 : (1<<4)) |
+           (PINB&(1<<4) ? 0 : (1<<5)) |
+           (PINB&(1<<5) ? 0 : (1<<6)) |
+           (PINB&(1<<6) ? 0 : (1<<7));
+}
+
+/*  These columns uses two 74HC42 4 to 10 bit demultiplexers (low active).
+ *
+ *   COL PD1 PD0 PD2 PD6 PD5 PD4
+ *   12   1   1   0   0   0   0
+ *   11   1   1   0   0   0   1
+ *   10   1   1   0   0   1   0
+ *    9   1   1   0   0   1   1
+ *    8   1   1   0   1   0   0
+ *    7   1   1   0   1   0   1
+ *    6   1   1   0   1   1   0
+ *    5   1   1   0   1   1   1
+ *    4   1   1   1   0   0   0
+ *    3   1   1   1   0   0   1
+
+ *   COL PD2 PD6 PD1 PD0 PD5 PD4
+ *    2   1   1   0   0   0   0
+ *    1   1   1   0   0   0   1
+ *    0   1   1   0   0   1   0
+ *   17   1   1   0   0   1   1
+ *   16   1   1   0   1   0   0
+ *        1   1   0   1   0   1
+ *        1   1   0   1   1   0
+ *   15   1   1   0   1   1   1
+ *   14   1   1   1   0   0   0
+ *   13   1   1   1   0   0   1
+ */
+static void unselect_cols(void)
+{
+    DDRD |= 0b01110111;
+    PORTD &= ~0b01110111;
+}
+
+static void select_col(uint8_t col)
+{
+    switch (col) {
+        case 0:
+            PORTD |= (1<<5) | (1<<6) | (1<<2);
+            break;
+        case 1:
+            PORTD |= (1<<4) | (1<<6) | (1<<2);
+            break;
+        case 2:
+            PORTD |= (1<<6) | (1<<2);
+            break;
+        case 3:
+            PORTD |= (1<<4) | (1<<2) | (1<<0) | (1<<1);
+            break;
+        case 4:
+            PORTD |= (1<<2) | (1<<0) | (1<<1);
+            break;
+        case 5:
+            PORTD |= (1<<4) | (1<<5) | (1<<6) | (1<<0) | (1<<1);
+            break;
+        case 6:
+            PORTD |= (1<<5) | (1<<6) | (1<<0) | (1<<1);
+            break;
+        case 7:
+            PORTD |= (1<<4) | (1<<6) | (1<<0) | (1<<1);
+            break;
+        case 8:
+            PORTD |= (1<<6) | (1<<0) | (1<<1);
+            break;
+        case 9:
+            PORTD |= (1<<4) | (1<<5) | (1<<0) | (1<<1);
+            break;
+        case 10:
+            PORTD |= (1<<5) | (1<<0) | (1<<1);
+            break;
+        case 11:
+            PORTD |= (1<<4) | (1<<0) | (1<<1);
+            break;
+        case 12:
+            PORTD |= (1<<0) | (1<<1);
+            break;
+        case 13:
+            PORTD |= (1<<4) | (1<<1) | (1<<6) | (1<<2);
+            break;
+        case 14:
+            PORTD |= (1<<1) | (1<<6) | (1<<2);
+            break;
+        case 15:
+            PORTD |= (1<<4) | (1<<5) | (1<<0) | (1<<6) | (1<<2);
+            break;
+        case 16:
+            PORTD |= (1<<0) | (1<<6) | (1<<2);
+            break;
+        case 17:
+            PORTD |= (1<<4) | (1<<5) | (1<<6) | (1<<2);
+            break;
+    }
+}


### PR DESCRIPTION
Hello Hasu,

this commit adds support for one of bpiphany's costar controllers called Kitten Paw. This controller is used for fullsize Majestouch keyboards.

See http://deskthority.net/wiki/Costar_replacement_controllers

I'm writing this pull request with the new firmware. I haven't tested nkey rollover yet, that's why it's disabled for now. There is only Lufa support for now.

Kind regards
xauser
