### PR TITLE
Fix usb_usb converter README

### DIFF
--- a/converter/usb_usb/README
+++ b/converter/usb_usb/README
@@ -16,9 +16,6 @@ Build firmware
     $ cd tmk_keyboard
     $ git submodule init
     $ git submodule update
-
-and download LUFA and unzip under protocol/lufa and edit LUFA_PATH in protocol/lufa.mk. Then,
-
     $ cd converter/usb_usb
     $ make
 


### PR DESCRIPTION
Hi, Is usb_usb currently compiling for you? 

Since it doesn't appear to have received a lot of attention I wonder if it hasn't gotten out of sync from the rest of TMK. I'd really like to get it working with SpaceFN but I don't know C so I'll try to point out some areas that might be wrong in hopes that you can check them out.

I'm pretty sure the usb_hid mention in the README is no longer needed. One of these commits removes it. 

I'm just guessing that the LUFA download mention is no longer needed either since it appears to be a submodule now and downloaded by the previous "git submodule update" command. One of these commits removes the mention.

I'm currently getting the following compilation errors on usb_usb:

https://www.refheap.com/90266/raw

I noticed that in protocol/usb_hid/USB_Host_Shield_2.0 there is a branch tmk_fix. Is that needed? It doesn't appear to make a difference for me.

How much work would adding SpaceFN keymap to usb_usb be?

Thanks,
Scott
