### PR TITLE
adb_usb: Enable NKRO by default

### DIFF
--- a/converter/adb_usb/Makefile
+++ b/converter/adb_usb/Makefile
@@ -120,8 +120,8 @@ MOUSEKEY_ENABLE = yes	# Mouse keys(+4700)
 EXTRAKEY_ENABLE = yes	# Audio control and System control(+450)
 CONSOLE_ENABLE = yes	# Console for debug(+400)
 COMMAND_ENABLE = yes    # Commands for debug and configuration
+NKRO_ENABLE = yes	# USB Nkey Rollover
 #SLEEP_LED_ENABLE = yes  # Breathing sleep LED during USB suspend
-#NKRO_ENABLE = yes	# USB Nkey Rollover - not yet supported in LUFA
 
 
 # Optimize size but this may cause error "relocation truncated to fit"


### PR DESCRIPTION
NKRO has been supported by the LUFA stack for a while now (as per #47 ), so the comment saying otherwise can be removed.
Since NKRO is very useful to have, activate it by default.
