### PR TITLE
Fix mistake for tmk/tmk_keyboard#160

### DIFF
--- a/common/keymap.c
+++ b/common/keymap.c
@@ -131,7 +131,7 @@ static action_t keycode_to_action(uint8_t keycode)
         case KC_SYSTEM_POWER ... KC_SYSTEM_WAKE:
             action.code = ACTION_USAGE_SYSTEM(KEYCODE2SYSTEM(keycode));
             break;
-        case KC_AUDIO_MUTE ... KC_WWW_FAVORITES:
+        case KC_AUDIO_MUTE ... KC_MEDIA_REWIND:
             action.code = ACTION_USAGE_CONSUMER(KEYCODE2CONSUMER(keycode));
             break;
         case KC_MS_UP ... KC_MS_ACCEL2:


### PR DESCRIPTION
I think this is a mistake by @mumchristmas 
This mistake makes ```KC_MEDIA_FAST_FORWARD``` and ```KC_MEDIA_REWIND``` report nothing.
I confirmed these two keys actually work well on my mac.