### PR TITLE
Add mouse support to ADB

### DIFF
--- a/converter/adb_usb/Makefile
+++ b/converter/adb_usb/Makefile
@@ -122,6 +122,10 @@ CONSOLE_ENABLE = yes	# Console for debug(+400)
 COMMAND_ENABLE = yes    # Commands for debug and configuration
 #SLEEP_LED_ENABLE = yes  # Breathing sleep LED during USB suspend
 #NKRO_ENABLE = yes	# USB Nkey Rollover
+ADB_MOUSE_ENABLE = yes
+
+# ADB Mice need acceleration for todays much bigger screens. 
+OPT_DEFS += -DADB_MOUSE_MAXACC=8
 
 
 # Optimize size but this may cause error "relocation truncated to fit"

--- a/converter/adb_usb/Makefile.pjrc
+++ b/converter/adb_usb/Makefile.pjrc
@@ -57,6 +57,10 @@ CONSOLE_ENABLE = yes    # Console for debug
 COMMAND_ENABLE = yes    # Commands for debug and configuration
 #SLEEP_LED_ENABLE = yes  # Breathing sleep LED during USB suspend
 #NKRO_ENABLE = yes	# USB Nkey Rollover(+500)
+ADB_MOUSE_ENABLE = yes
+
+# ADB Mice need acceleration for todays much bigger screens. 
+OPT_DEFS += -DADB_MOUSE_MAXACC=8
 
 
 # Search Path

--- a/tmk_core/common/keyboard.c
+++ b/tmk_core/common/keyboard.c
@@ -39,6 +39,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifdef SERIAL_MOUSE_ENABLE
 #include "serial_mouse.h"
 #endif
+#ifdef ADB_MOUSE_ENABLE
+#include "adb.h"
+#endif
 
 
 #ifdef MATRIX_HAS_GHOST
@@ -68,6 +71,9 @@ void keyboard_init(void)
 #endif
 #ifdef SERIAL_MOUSE_ENABLE
     serial_mouse_init();
+#endif
+#ifdef ADB_MOUSE_ENABLE
+    adb_mouse_init();
 #endif
 
 
@@ -145,6 +151,10 @@ MATRIX_LOOP_END:
 
 #ifdef SERIAL_MOUSE_ENABLE
         serial_mouse_task();
+#endif
+
+#ifdef ADB_MOUSE_ENABLE
+        adb_mouse_task();
 #endif
 
     // update LED

--- a/tmk_core/protocol.mk
+++ b/tmk_core/protocol.mk
@@ -46,5 +46,9 @@ ifdef SERIAL_MOUSE_USE_UART
     SRC += $(PROTOCOL_DIR)/serial_uart.c
 endif
 
+ifdef ADB_MOUSE_ENABLE
+	 OPT_DEFS += -DADB_MOUSE_ENABLE -DMOUSE_ENABLE
+endif
+
 # Search Path
 VPATH += $(TMK_DIR)/protocol

--- a/tmk_core/protocol/adb.c
+++ b/tmk_core/protocol/adb.c
@@ -60,6 +60,7 @@ static inline void place_bit1(void);
 static inline void send_byte(uint8_t data);
 static inline uint16_t wait_data_lo(uint16_t us);
 static inline uint16_t wait_data_hi(uint16_t us);
+static inline uint16_t adb_host_dev_recv(uint8_t device);
 
 
 void adb_host_init(void)
@@ -121,12 +122,33 @@ bool adb_host_psw(void)
 //
 // [from Apple IIgs Hardware Reference Second Edition]
 
+enum {
+    ADDR_KEYB  = 0x20,
+    ADDR_MOUSE = 0x30
+};
+
 uint16_t adb_host_kbd_recv(void)
+{
+    return adb_host_dev_recv(ADDR_KEYB);
+}
+
+#ifdef ADB_MOUSE_ENABLE
+void adb_mouse_init(void) {
+	    return;
+}
+
+uint16_t adb_host_mouse_recv(void)
+{
+    return adb_host_dev_recv(ADDR_MOUSE);
+}
+#endif
+
+static inline uint16_t adb_host_dev_recv(uint8_t device)
 {
     uint16_t data = 0;
     cli();
     attention();
-    send_byte(0x2C);            // Addr:Keyboard(0010), Cmd:Talk(11), Register0(00)
+    send_byte(device|0x0C);     // Addr:Keyboard(0010)/Mouse(0011), Cmd:Talk(11), Register0(00)
     place_bit0();               // Stopbit(0)
     if (!wait_data_hi(500)) {    // Service Request(310us Adjustable Keyboard): just ignored
         sei();

--- a/tmk_core/protocol/adb.h
+++ b/tmk_core/protocol/adb.h
@@ -56,7 +56,11 @@ POSSIBILITY OF SUCH DAMAGE.
 void     adb_host_init(void);
 bool     adb_host_psw(void);
 uint16_t adb_host_kbd_recv(void);
+uint16_t adb_host_mouse_recv(void);
 void     adb_host_listen(uint8_t cmd, uint8_t data_h, uint8_t data_l);
 void     adb_host_kbd_led(uint8_t led);
+void     adb_mouse_task(void);
+void     adb_mouse_init(void);
+
 
 #endif

--- a/tmk_core/protocol/pjrc.mk
+++ b/tmk_core/protocol/pjrc.mk
@@ -11,6 +11,10 @@ ifdef MOUSEKEY_ENABLE
     SRC += $(PJRC_DIR)/usb_mouse.c
 endif
 
+ifdef ADB_MOUSE_ENABLE
+    SRC += $(PJRC_DIR)/usb_mouse.c
+endif
+
 ifdef PS2_MOUSE_ENABLE
     SRC += $(PJRC_DIR)/usb_mouse.c
 endif


### PR DESCRIPTION
Adding the makefile options ADB_MOUSE_ENABLE and ADB_MOUSE_ACCMAX.
Might have gone overboard with comments, and tried but failed at not
adding more than necessary outside the converter/adb_usb/ folder.