### PR TITLE
Make action_for_key a weak symbol

### DIFF
--- a/tmk_core/common/action.h
+++ b/tmk_core/common/action.h
@@ -51,6 +51,7 @@ void action_exec(keyevent_t event);
 
 /* action for key */
 action_t action_for_key(uint8_t layer, keypos_t key);
+action_t action_for_key_default(uint8_t layer, keypos_t key);
 
 /* macro */
 const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt);

--- a/tmk_core/common/keymap.c
+++ b/tmk_core/common/keymap.c
@@ -27,8 +27,13 @@ static action_t keycode_to_action(uint8_t keycode);
 
 
 /* converts key to action */
+__attribute__((__weak__))
 action_t action_for_key(uint8_t layer, keypos_t key)
 {
+	return action_for_key_default(layer, key);
+}
+
+action_t action_for_key_default(uint8_t layer, keypos_t key)
     uint8_t keycode = keymap_key_to_keycode(layer, key);
     switch (keycode) {
         case KC_FN0 ... KC_FN31:


### PR DESCRIPTION
This allows a consumer to override this function while retaining the ability to reuse the default implementation.