### PR TITLE
Add an assignable RESET key

### DIFF
--- a/tmk_core/common/keycode.h
+++ b/tmk_core/common/keycode.h
@@ -426,6 +426,9 @@ enum internal_special_keycodes {
     KC_MEDIA_FAST_FORWARD,
     KC_MEDIA_REWIND,    /* 0xBC */
 
+    /* Jump to bootloader */
+    KC_RESET            = 0xBF,
+
     /* Fn key */
     KC_FN0              = 0xC0,
     KC_FN1,

--- a/tmk_core/common/keymap.c
+++ b/tmk_core/common/keymap.c
@@ -14,6 +14,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include <util/delay.h>
 #include "keymap.h"
 #include "report.h"
 #include "keycode.h"
@@ -21,6 +22,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "action.h"
 #include "action_macro.h"
 #include "debug.h"
+#include "print.h"
 
 
 static action_t keycode_to_action(uint8_t keycode);
@@ -139,6 +141,13 @@ static action_t keycode_to_action(uint8_t keycode)
             break;
         case KC_TRNS:
             action.code = ACTION_TRANSPARENT;
+            break;
+        case KC_RESET:
+            clear_keyboard();
+            print("\n\nJump to bootloader... ");
+            _delay_ms(50);
+            bootloader_jump();
+            print("not supported.\n");
             break;
         default:
             action.code = ACTION_NO;


### PR DESCRIPTION
I wanted an assignable RESET key, similar to what the ergodox and the planck have, but I didn't want to have to duplicate code between my different keyboard projects. I'm aware that you can use MAGIC+pause but not all keyboards have a pause key, and overriding that combination starts to get complicated.

I tested this using adb_converter and it seemed to work great.