### PR TITLE
Remove an errant comma trailing the KC_ERAS macro alias

### DIFF
--- a/tmk_core/common/keycode.h
+++ b/tmk_core/common/keycode.h
@@ -85,7 +85,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define KC_LCAP KC_LOCKING_CAPS
 #define KC_LNUM KC_LOCKING_NUM
 #define KC_LSCR KC_LOCKING_SCROLL
-#define KC_ERAS KC_ALT_ERASE,
+#define KC_ERAS KC_ALT_ERASE
 #define KC_CLR  KC_CLEAR
 /* Japanese specific */
 #define KC_ZKHK KC_GRAVE


### PR DESCRIPTION
This was causing compilation failures on any keymaps that used the `ERAS` key macro, which is only used in [news_usb](/tmk/tmk_keyboard/blob/a5f2892/converter/news_usb/keymap.c) currently.