### PR TITLE
Resolve keymap.c warnings

### DIFF
--- a/tmk_core/common/bootloader.h
+++ b/tmk_core/common/bootloader.h
@@ -18,8 +18,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef BOOTLOADER_H
 #define BOOTLOADER_H
 
+#include <stdlib.h>
 
 /* give code for your bootloader to come up if needed */
-void bootloader_jump(void);
+void bootloader_jump(void) __ATTR_NORETURN__;
 
 #endif

--- a/tmk_core/common/keymap.c
+++ b/tmk_core/common/keymap.c
@@ -22,6 +22,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "action_macro.h"
 #include "wait.h"
 #include "debug.h"
+#include "bootloader.h"
 
 
 static action_t keycode_to_action(uint8_t keycode);


### PR DESCRIPTION
Hello,

Thanks for your amazing firmware, it's making my project much easier.
While working on it, I found out that the current keymap.c code triggers two warnings: 
1. bootloader_jump is not defined
2. the action variable might not have been initialized

This pull request adds the missing include for point 1 and the appropriate attribute for point 2.

Regards,
obones