### PR TITLE
Fix warning in command.c

### DIFF
--- a/tmk_core/common/command.c
+++ b/tmk_core/common/command.c
@@ -178,7 +178,9 @@ static void print_eeconfig(void)
 
 static bool command_common(uint8_t code)
 {
+#ifdef KEYBOARD_LOCK_ENABLE
     static host_driver_t *host_driver = 0;
+#endif
     switch (code) {
 #ifdef SLEEP_LED_ENABLE
         case KC_Z:


### PR DESCRIPTION
Hello,

command.c defines the host_driver static variable but it is only used if KEYBOARD_LOCK_ENABLE is defined.

In my case KEYBOARD_LOCK_ENABLE is not defined so it triggers a warning.
This pull request encloses the declaration inside a #ifdef statement to avoid that warning.