### PR TITLE
remove  SERIAL_SOFT_DEBUG macro

### DIFF
--- a/tmk_core/protocol/serial_soft.c
+++ b/tmk_core/protocol/serial_soft.c
@@ -68,7 +68,6 @@ POSSIBILITY OF SUCH DAMAGE.
 #endif
 
 /* debug for signal timing, see debug pin with oscilloscope */
-#define SERIAL_SOFT_DEBUG
 #ifdef SERIAL_SOFT_DEBUG
     #define SERIAL_SOFT_DEBUG_INIT()    (DDRD |= 1<<7)
     #define SERIAL_SOFT_DEBUG_TGL()     (PORTD ^= 1<<7)
@@ -176,7 +175,7 @@ void serial_send(uint8_t data)
 ISR(SERIAL_SOFT_RXD_VECT)
 {
     SERIAL_SOFT_DEBUG_TGL();
-    SERIAL_SOFT_RXD_INT_ENTER()
+    SERIAL_SOFT_RXD_INT_ENTER();
 
     uint8_t data = 0;
 


### PR DESCRIPTION
SERIAL_SOFT_DEBUG can be defined in the `config.h`