### PR TITLE
core: Speed up compilation

### DIFF
--- a/tmk_core/common.mk
+++ b/tmk_core/common.mk
@@ -81,7 +81,8 @@ ifdef KEYMAP_SECTION_ENABLE
 endif
 
 # Version string
-OPT_DEFS += -DVERSION=$(shell (git describe --always --dirty || echo 'unknown') 2> /dev/null)
+VERSION := $(shell (git describe --always --dirty || echo 'unknown') 2> /dev/null)
+OPT_DEFS += -DVERSION=$(VERSION)
 
 
 # Search Path


### PR DESCRIPTION
In my environment (Windows/Cygwin), compilation is very slow. Then I noticed that the git process is using a very high CPU usage when compiling.

I found the cause is that the current make rule attempts to obtain version information by calling git when compiling EVERY files. So after I moved the command substitution to a simply expanded variable, the compilation is much faster than before.

I think this change has not influence on version information. And it is quite effective in my environment.