### PR TITLE
Added keyboard_startup (that calls matrix_startup) to allow initializing the keyboard when host driver is set

### DIFF
--- a/keyboard/hhkb/rn42/main.c
+++ b/keyboard/hhkb/rn42/main.c
@@ -81,6 +81,7 @@ int main(void)
 #ifdef SLEEP_LED_ENABLE
     sleep_led_init();
 #endif
+    keyboard_startup();
 
     print("Keyboard start\n");
     while (1) {

--- a/tmk_core/common/keyboard.c
+++ b/tmk_core/common/keyboard.c
@@ -68,6 +68,12 @@ void keyboard_setup(void)
     matrix_setup();
 }
 
+__attribute__ ((weak)) void matrix_startup(void) {}
+void keyboard_startup(void)
+{
+    matrix_startup();
+}
+
 void keyboard_init(void)
 {
     timer_init();

--- a/tmk_core/common/keyboard.h
+++ b/tmk_core/common/keyboard.h
@@ -62,6 +62,8 @@ static inline bool IS_RELEASED(keyevent_t event) { return (!IS_NOEVENT(event) &&
 void keyboard_setup(void);
 /* it runs once after initializing host side protocol, debug and MCU peripherals. */
 void keyboard_init(void);
+/* it runs once right before going into the main loop. The driver is set when this is called. */
+void keyboard_startup(void);
 /* it runs repeatedly in main loop */
 void keyboard_task(void);
 /* it runs when host LED status is updated */

--- a/tmk_core/common/matrix.h
+++ b/tmk_core/common/matrix.h
@@ -47,6 +47,8 @@ uint8_t matrix_cols(void);
 void matrix_setup(void);
 /* intialize matrix for scaning. */
 void matrix_init(void);
+/* called at early stage of startup after matrix_init when host driver is set.(optional) */
+void matrix_startup(void);
 /* scan all key states on matrix */
 uint8_t matrix_scan(void);
 /* whether modified from previous scan. used after matrix_scan. */

--- a/tmk_core/protocol/bluefruit/main.c
+++ b/tmk_core/protocol/bluefruit/main.c
@@ -82,6 +82,8 @@ int main(void)
         // to load drivers and do whatever it does to actually
         // be ready for input
         _delay_ms(1000);
+        keyboard_startup();
+        
         PORTD = ~_BV(PD5);
         dprintf("Starting main loop");
         while (1) {
@@ -100,6 +102,8 @@ int main(void)
         // to load drivers and do whatever it does to actually
         // be ready for input
         _delay_ms(1000);
+        keyboard_startup();
+        
         PORTB = ~_BV(PB0);
         dprintf("Starting main loop");
         while (1) {

--- a/tmk_core/protocol/chibios/main.c
+++ b/tmk_core/protocol/chibios/main.c
@@ -110,6 +110,7 @@ int main(void) {
 #ifdef SLEEP_LED_ENABLE
   sleep_led_init();
 #endif
+  keyboard_startup();
 
   print("Keyboard start.\n");
 

--- a/tmk_core/protocol/iwrap/main.c
+++ b/tmk_core/protocol/iwrap/main.c
@@ -161,6 +161,8 @@ int main(void)
     iwrap_init();
     iwrap_call();
 
+    keyboard_startup();
+    
     last_timer = timer_read();
     while (true) {
 #ifdef PROTOCOL_VUSB

--- a/tmk_core/protocol/lufa/lufa.c
+++ b/tmk_core/protocol/lufa/lufa.c
@@ -612,6 +612,7 @@ int main(void)
 #ifdef SLEEP_LED_ENABLE
     sleep_led_init();
 #endif
+    keyboard_startup();
 
     print("Keyboard start.\n");
     while (1) {

--- a/tmk_core/protocol/pjrc/main.c
+++ b/tmk_core/protocol/pjrc/main.c
@@ -61,6 +61,7 @@ int main(void)
 #ifdef SLEEP_LED_ENABLE
     sleep_led_init();
 #endif
+    keyboard_startup();
     while (1) {
         while (suspend) {
             suspend_power_down();

--- a/tmk_core/protocol/vusb/main.c
+++ b/tmk_core/protocol/vusb/main.c
@@ -58,6 +58,7 @@ int main(void)
 
     debug("initForUsbConnectivity()\n");
     initForUsbConnectivity();
+    keyboard_startup();
 
     debug("main loop\n");
     while (1) {


### PR DESCRIPTION
In some setup, one may want to initialize a keyboard to a given layer depending on information from the host as there might be a specific layer for when `NumLock` is on.
Using `matrix_setup` is not possible because USB is not started
Using `matrix_init` is not possible because driver variable is not set

This pull request introduces `keyboard_startup` that calls `matrix_startup` to allow putting code in there that calls code such as `host_keyboard_leds` and react accordingly.