### PR TITLE
Add layer-switching on ps/2 mouse movement

### DIFF
--- a/tmk_core/protocol/ps2_mouse.h
+++ b/tmk_core/protocol/ps2_mouse.h
@@ -63,4 +63,18 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 uint8_t ps2_mouse_init(void);
 void ps2_mouse_task(void);
 
+#ifdef AUTO_MOUSE_LAYER
+extern uint8_t tp_buttons;
+typedef enum {AML_UNSET, AML_STARTUP, AML_SET} mlh_t;
+/* you can set delays in your config.h or use these defaults */
+#ifndef AML_STARTUP_TIME
+    #define AML_STARTUP_TIME 100
+#endif
+#ifndef AML_DURATION
+    #define AML_DURATION 800
+#endif
+
+extern mlh_t  mouse_layer_helper;
+#endif
+
 #endif


### PR DESCRIPTION
Changes are intended for trackpoints in the alphaarea, when no dedicated
mousebuttons are used.
Movement of the trackpoint will activate layer
MOUSELAYER until neither the trackpoint moves or the mousebuttons are pressed
for a threshold time. Also pressing any non-modifier/non-mousebutton keys will
deactivate that layer early.