### PR TITLE
Update macro names in bluefruit protocol

### DIFF
--- a/tmk_core/protocol/bluefruit/bluefruit.c
+++ b/tmk_core/protocol/bluefruit/bluefruit.c
@@ -150,25 +150,25 @@ static void send_system(uint16_t data)
 +-------------------------------------+-------+
 */
 #define CONSUMER2BLUEFRUIT(usage) \
-    (usage == AUDIO_MUTE           ? 0x0000  : \
-    (usage == AUDIO_VOL_UP         ? 0x1000  : \
-    (usage == AUDIO_VOL_DOWN       ? 0x2000  : \
-    (usage == TRANSPORT_NEXT_TRACK ? 0x0002  : \
-    (usage == TRANSPORT_PREV_TRACK ? 0x0004  : \
-    (usage == TRANSPORT_STOP       ? 0x0010  : \
-    (usage == TRANSPORT_STOP_EJECT ? 0x0000  : \
-    (usage == TRANSPORT_PLAY_PAUSE ? 0x4000  : \
-    (usage == AL_CC_CONFIG         ? 0x0000  : \
-    (usage == AL_EMAIL             ? 0x0000  : \
-    (usage == AL_CALCULATOR        ? 0x0000  : \
-    (usage == AL_LOCAL_BROWSER     ? 0x0000  : \
-    (usage == AC_SEARCH            ? 0x0400  : \
-    (usage == AC_HOME              ? 0x0100  : \
-    (usage == AC_BACK              ? 0x0000  : \
-    (usage == AC_FORWARD           ? 0x0000  : \
-    (usage == AC_STOP              ? 0x0000  : \
-    (usage == AC_REFRESH           ? 0x0000  : \
-    (usage == AC_BOOKMARKS         ? 0x0000  : 0)))))))))))))))))))
+    (usage == AUDIO_MUTE              ? 0x0000  : \
+    (usage == AUDIO_VOL_UP            ? 0x1000  : \
+    (usage == AUDIO_VOL_DOWN          ? 0x2000  : \
+    (usage == TRANSPORT_NEXT_TRACK    ? 0x0002  : \
+    (usage == TRANSPORT_PREV_TRACK    ? 0x0004  : \
+    (usage == TRANSPORT_STOP          ? 0x0010  : \
+    (usage == TRANSPORT_STOP_EJECT    ? 0x0000  : \
+    (usage == TRANSPORT_PLAY_PAUSE    ? 0x4000  : \
+    (usage == APPLAUNCH_CC_CONFIG     ? 0x0000  : \
+    (usage == APPLAUNCH_EMAIL         ? 0x0000  : \
+    (usage == APPLAUNCH_CALCULATOR    ? 0x0000  : \
+    (usage == APPLAUNCH_LOCAL_BROWSER ? 0x0000  : \
+    (usage == APPCONTROL_SEARCH       ? 0x0400  : \
+    (usage == APPCONTROL_HOME         ? 0x0100  : \
+    (usage == APPCONTROL_BACK         ? 0x0000  : \
+    (usage == APPCONTROL_FORWARD      ? 0x0000  : \
+    (usage == APPCONTROL_STOP         ? 0x0000  : \
+    (usage == APPCONTROL_REFRESH      ? 0x0000  : \
+    (usage == APPCONTROL_BOOKMARKS    ? 0x0000  : 0)))))))))))))))))))
 
 static void send_consumer(uint16_t data)
 {


### PR DESCRIPTION
This PR updates the macro names in bluefruit.c to the correct names as described in https://github.com/tmk/tmk_keyboard/issues/339