### PR TITLE
Implement hhkb with the new driver interface

### DIFF
--- a/keyboard/hhkb/rn42/main.c
+++ b/keyboard/hhkb/rn42/main.c
@@ -1,17 +1,8 @@
 #include <avr/io.h>
-#include <avr/power.h>
-#include <avr/wdt.h>
 #include "lufa.h"
 #include "print.h"
 #include "sendchar.h"
 #include "rn42.h"
-#include "rn42_task.h"
-#include "serial.h"
-#include "keyboard.h"
-#include "keycode.h"
-#include "action.h"
-#include "action_util.h"
-#include "wait.h"
 #include "suart.h"
 #include "suspend.h"
 
@@ -22,24 +13,23 @@ static int8_t sendchar_func(uint8_t c)
     return 0;
 }
 
-static void SetupHardware(void)
-{
-    /* Disable watchdog if enabled by bootloader/fuses */
-    MCUSR &= ~(1 << WDRF);
-    wdt_disable();
+static host_driver_configuration_t driver_configuration = {
+    .num_drivers = 2,
+	.connection_timeout = 4000,
+	.connection_delay = 50,
+	.try_connect_all = true,
+    .drivers = {
+        &rn42_driver,
+        &lufa_driver,
+    }
+};
 
-    /* Disable clock division */
-    clock_prescale_set(clock_div_1);
+host_driver_configuration_t* hook_get_driver_configuration(void) {
+    return &driver_configuration;
+}
 
-    // Leonardo needs. Without this USB device is not recognized.
-    USB_Disable();
-
-    USB_Init();
-
-    // for Console_Task
-    USB_Device_EnableSOFEvents();
+void hook_early_init(void) {
     print_set_sendchar(sendchar_func);
-
     // SUART PD0:output, PD1:input
     DDRD |= (1<<0);
     PORTD |= (1<<0);
@@ -47,65 +37,13 @@ static void SetupHardware(void)
     PORTD |= (1<<1);
 }
 
-int main(void)  __attribute__ ((weak));
-int main(void)
-{
-    SetupHardware();
-    sei();
-
-    /* wait for USB startup to get ready for debug output */
-    uint8_t timeout = 255;  // timeout when USB is not available(Bluetooth)
-    while (timeout-- && USB_DeviceState != DEVICE_STATE_Configured) {
-        wait_ms(4);
-#if defined(INTERRUPT_CONTROL_ENDPOINT)
-        ;
-#else
-        USB_USBTask();
-#endif
-    }
-    print("\nUSB init\n");
-
-    rn42_init();
-    rn42_task_init();
-    print("RN-42 init\n");
-
-    /* init modules */
-    keyboard_init();
-
-    if (!rn42_rts()) {
-        host_set_driver(&rn42_driver);
-    } else {
-        host_set_driver(&lufa_driver);
-    }
-
-#ifdef SLEEP_LED_ENABLE
-    sleep_led_init();
-#endif
-
-    print("Keyboard start\n");
-    while (1) {
-        while (rn42_rts() && // RN42 is off
-                USB_DeviceState == DEVICE_STATE_Suspended) {
-            print("[s]");
-            matrix_power_down();
-            suspend_power_down();
-            suspend_power_down();
-            suspend_power_down();
-            suspend_power_down();
-            suspend_power_down();
-            suspend_power_down();
-            suspend_power_down();
-            if (USB_Device_RemoteWakeupEnabled && suspend_wakeup_condition()) {
-                    USB_Device_SendRemoteWakeup();
-            }
-        }
-
-        keyboard_task();
-
-#if !defined(INTERRUPT_CONTROL_ENDPOINT)
-        USB_USBTask();
-#endif
-
-        rn42_task();
-    }
+void hook_usb_suspend_loop(void) {
+	// Is it really needed to call this multiple times?
+	suspend_power_down();
+	suspend_power_down();
+	suspend_power_down();
+	suspend_power_down();
+	suspend_power_down();
+	suspend_power_down();
+	suspend_power_down();
 }


### PR DESCRIPTION
Here's the HHKB rn42 bluetooth interace implemented using the generic driver interface in pull request https://github.com/tmk/tmk_core/pull/19.

I think all old functionality should be maintained, but I don't have the hardware to test.

You might be wondering about 
```
       while (rn42_rts() && // RN42 is off
               USB_DeviceState == DEVICE_STATE_Suspended) {
```

That condition is still satisfied with the generic implementation, due to the fact that the driver is changed to the Bluetooth one on the fly. And that driver will never return a suspended state. So just like before, if the Bluetooth is on, then the keyboard can never suspend.

I'm not sure if that's what it's supposed to do, but that's what the code appears to do currently.
