### PR TITLE
Implemented oneshot toggle functions and action macro.

### DIFF
--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -130,6 +130,11 @@ void process_action(keyrecord_t *record)
                         }
                         break;
     #endif
+                    case MODS_ONESHOT_TOGGLE:
+                        if (event.pressed) {
+                           oneshot_toggle();
+                        }
+                        break;
                     case MODS_TAP_TOGGLE:
                         if (event.pressed) {
                             if (tap_count <= TAPPING_TOGGLE) {

--- a/tmk_core/common/action_code.h
+++ b/tmk_core/common/action_code.h
@@ -35,6 +35,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  * ACT_MODS_TAP(001r):
  * 001r|mods|0000 0000    Modifiers with OneShot
  * 001r|mods|0000 0001    Modifiers with tap toggle
+ * 001r|0000|0000 0010    Toggle all OneShot active/inactive
  * 001r|mods|0000 00xx    (reserved)
  * 001r|mods| keycode     Modifiers with Tap Key(Dual role)
  *
@@ -209,6 +210,7 @@ enum mods_bit {
 enum mods_codes {
     MODS_ONESHOT = 0x00,
     MODS_TAP_TOGGLE = 0x01,
+    MODS_ONESHOT_TOGGLE = 0x10,
 };
 #define ACTION_KEY(key)                 ACTION(ACT_MODS, (key))
 #define ACTION_MODS(mods)               ACTION(ACT_MODS, ((mods)&0x1f)<<8 | 0)
@@ -216,7 +218,7 @@ enum mods_codes {
 #define ACTION_MODS_TAP_KEY(mods, key)  ACTION(ACT_MODS_TAP, ((mods)&0x1f)<<8 | (key))
 #define ACTION_MODS_ONESHOT(mods)       ACTION(ACT_MODS_TAP, ((mods)&0x1f)<<8 | MODS_ONESHOT)
 #define ACTION_MODS_TAP_TOGGLE(mods)    ACTION(ACT_MODS_TAP, ((mods)&0x1f)<<8 | MODS_TAP_TOGGLE)
-
+#define ACTION_MODS_ONESHOT_TOGGLE()    ACTION(ACT_MODS_TAP, MODS_ONESHOT_TOGGLE)
 
 /*
  * Other Keys

--- a/tmk_core/common/action_util.c
+++ b/tmk_core/common/action_util.c
@@ -46,11 +46,24 @@ report_keyboard_t *keyboard_report = &(report_keyboard_t){};
 
 #ifndef NO_ACTION_ONESHOT
 static int8_t oneshot_mods = 0;
+static bool oneshot_active = true;
 #if (defined(ONESHOT_TIMEOUT) && (ONESHOT_TIMEOUT > 0))
 static int16_t oneshot_time = 0;
 #endif
 #endif
 
+void oneshot_toggle(void) {
+    oneshot_active = ! oneshot_active;
+    dprintf("Oneshot: active: %d\n",oneshot_active);
+}
+
+void oneshot_enable(void) {
+    oneshot_active = true;
+}
+
+void oneshot_disable(void) {
+    oneshot_active = false;
+}
 
 void send_keyboard_report(void) {
     keyboard_report->mods  = real_mods;
@@ -122,10 +135,12 @@ void clear_weak_mods(void) { weak_mods = 0; }
 #ifndef NO_ACTION_ONESHOT
 void set_oneshot_mods(uint8_t mods)
 {
-    oneshot_mods = mods;
+    if ( oneshot_active ) {
+        oneshot_mods = mods;
 #if (defined(ONESHOT_TIMEOUT) && (ONESHOT_TIMEOUT > 0))
-    oneshot_time = timer_read();
+        oneshot_time = timer_read();
 #endif
+     }
 }
 void clear_oneshot_mods(void)
 {
@@ -135,8 +150,6 @@ void clear_oneshot_mods(void)
 #endif
 }
 #endif
-
-
 
 
 /*

--- a/tmk_core/doc/keymap.md
+++ b/tmk_core/doc/keymap.md
@@ -578,12 +578,15 @@ Say you want to type 'The', you have to push and hold Shift key before type 't' 
 
 Oneshot effect is cancel unless following key is pressed down within `ONESHOT_TIMEOUT` of `config.h`. No timeout when it is `0` or not defined.
 
+Oneshot modifiers can be turned on or off by using the following action.  This affects any modifiers that have been set as oneshot modifiers in the keymap or actionmap.  So if a the above action was set (oneshot modifier on left shift) and then this action is called once, the left shift will behave normally.  If the toggle action is called again, left shift will behave as a oneshot modifier.
+
+    ACTION_MODS_ONESHOT_TOGGLE()
+
 
 ### 4.4 Tap Toggle Mods
 Similar to layer tap toggle, this works as a momentary modifier when holding, but toggles on with several taps. A single tap will 'unstick' the modifier again.
 
     ACTION_MODS_TAP_TOGGLE(MOD_LSFT)
-
 
 
 


### PR DESCRIPTION
This branch implements the following functions to control oneshot behavior and adds an action macro ACTION_MODS_ONESHOT_TOGGLE() to call the toggle function.

- oneshot_toggle()
- oneshot_enable()
- oneshot_disable()

If oneshot is disabled, then any key marked as oneshot behaves normally.  When oneshot is enabled (the default), keys marked as oneshot work that way.  It does not turn any modifier into a oneshot modifier - only mods marked that way in the action map will work as oneshots.  This just allows that behavior to be turned off if desired.

This makes it easy to experiment in a keymap with oneshot modifiers.  They can be declared as oneshot mods and another key can be designated to turn the oneshot behavior on and off.  So the deciding to use oneshots or not is a software switch controlled from the keyboard instead of requiring a change to the firmware.