### PR TITLE
README missing link

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ https://github.com/tmk/tmk_keyboard/wiki/TMK-Based-Projects
 [PC98]:         http://en.wikipedia.org/wiki/NEC_PC-9801
 [Sun]:          http://en.wikipedia.org/wiki/Sun-3
 [Infinity]:     https://www.massdrop.com/buy/infinity-keyboard-kit
+[tmk_core]:     https://github.com/tmk/tmk_core
 
 
 


### PR DESCRIPTION
Fixes a link made in this commit:
https://github.com/tmk/tmk_keyboard/commit/885e7adb18fb6039f0fe66de23e0622af923f7d1#diff-04c6e90faac2675aa89e2176d2eec7d8R3