### PR TITLE
Add support for Infinity 60% 1.1a

### DIFF
--- a/keyboard/infinity/README
+++ b/keyboard/infinity/README
@@ -26,8 +26,12 @@ http://cache.freescale.com/files/32bit/doc/data_sheet/K20P48M50SF0.pdf
 Pin Usage
 =========
 Key Matrix:
-    Strobe(output high):            PTB0 PTB1 PTB2 PTB3 PTB16 PTB17 PTC4 PTC5 PTD0
-    Sense(input with pull-down):    PTD1 PTD2 PTD3 PTD4 PTD5 PTD6 PTD7
+	For v1.0 (without LED support)
+		strobe(output high):            ptb0 ptb1 ptb2 ptb3 ptb16 ptb17 ptc4 ptc5 ptd0
+		sense(input with pull-down):    ptd1 ptd2 ptd3 ptd4 ptd5 ptd6 ptd7
+	For v1.1a (with LED support)
+		strobe(output high):            ptc0 ptc1 ptc2 ptc3 ptc4 ptc5 ptc6 ptc7 ptd0
+		sense(input with pull-down):    ptd1 ptd2 ptd3 ptd4 ptd5 ptd6 ptd7
 
 
 SWD pinout:
@@ -47,7 +51,7 @@ kiibohd bootloader: Lib/mk20dx128vlf5.bootloader.ld
             | .vectors          | ------------.    | StackPointer0 |     of Bootloader
             | .startup          |              \   | ResetHandler1 |
             | .rodata           |               `--+---------------+ 0xF8
-0x0000_0400 | .flashconfig(0x10)| 
+0x0000_0400 | .flashconfig(0x10)|
       _0410 | .text             |
             | .init             |
 0x0000_1000 +-------------------+ -----------------+---------------+ Vector table
@@ -62,7 +66,7 @@ kiibohd bootloader: Lib/mk20dx128vlf5.bootloader.ld
 
 0x1FFF_E000 +-------------------+ -----------------+---------------+ Vector table
       _E0F8 |                   | ------------.    |               |     of App(copied)
-            |                   |              \   |               |  
+            |                   |              \   |               |
             |                   |               `--+---------------+ mbed NVIC
             |                   |
             | RAM               |

--- a/keyboard/infinity/config.h
+++ b/keyboard/infinity/config.h
@@ -34,10 +34,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MATRIX_COLS 7   // Sense
 
 /* key combination for command */
-#define IS_COMMAND() (keyboard_report->mods == (MOD_BIT(KC_LSHIFT) | MOD_BIT(KC_RSHIFT))) 
+#define IS_COMMAND() (keyboard_report->mods == (MOD_BIT(KC_LSHIFT) | MOD_BIT(KC_RSHIFT)))
 
 
 /* for prototype */
 //#define INFINITY_PROTOTYPE
+
+/* Version 1.1a of the board */
+//#define INFINITY_LED
 
 #endif

--- a/keyboard/infinity/led.c
+++ b/keyboard/infinity/led.c
@@ -19,7 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "led.h"
 
 
-/* HHKB has no LEDs */
+/* TODO: setup led support for 1.1a version of the board */
 void led_set(uint8_t usb_led)
 {
 }

--- a/keyboard/infinity/matrix.c
+++ b/keyboard/infinity/matrix.c
@@ -39,6 +39,7 @@ void matrix_init(void)
     gpio_init_in_ex(&col[5], PTD6, PullDown);
     gpio_init_in_ex(&col[6], PTD7, PullDown);
 
+#ifdef INFINITY_LED
     /* Row(strobe) */
     gpio_init_out_ex(&row[0], PTB0, 0);
     gpio_init_out_ex(&row[1], PTB1, 0);
@@ -49,6 +50,18 @@ void matrix_init(void)
     gpio_init_out_ex(&row[6], PTC4, 0);
     gpio_init_out_ex(&row[7], PTC5, 0);
     gpio_init_out_ex(&row[8], PTD0, 0);
+#else
+    gpio_init_out_ex(&row[0], PTC0, 0);
+    gpio_init_out_ex(&row[1], PTC1, 0);
+    gpio_init_out_ex(&row[2], PTC2, 0);
+    gpio_init_out_ex(&row[3], PTC3, 0);
+    gpio_init_out_ex(&row[4], PTC4, 0);
+    gpio_init_out_ex(&row[5], PTC5, 0);
+    gpio_init_out_ex(&row[6], PTC6, 0);
+    gpio_init_out_ex(&row[7], PTC7, 0);
+    gpio_init_out_ex(&row[8], PTD0, 0);
+
+#endif
 }
 
 uint8_t matrix_scan(void)


### PR DESCRIPTION
The newest version of the Infinity keyboard has a slightly different
matrix and LED support.

This just adds support for the matrix.

Flashed and tested on my IC60 1.1a.