### PR TITLE
Support for more than 32 FN keys

### DIFF
--- a/tmk_core/common/keycode.h
+++ b/tmk_core/common/keycode.h
@@ -32,9 +32,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define IS_SPECIAL(code)         ((0xA5 <= (code) && (code) <= 0xDF) || (0xE8 <= (code) && (code) <= 0xFF))
 #define IS_SYSTEM(code)          (KC_PWR       <= (code) && (code) <= KC_WAKE)
 #define IS_CONSUMER(code)        (KC_MUTE      <= (code) && (code) <= KC_WFAV)
-/* seems unused
-#define IS_FN(code)              (KC_FN0       <= (code) && (code) <= KC_FN40)
-*/
+#define IS_FN(code)              (KC_FN0       <= (code) && (code) <= KC_FN31)
 #define IS_MOUSEKEY(code)        (KC_MS_UP     <= (code) && (code) <= KC_MS_ACCEL2)
 #define IS_MOUSEKEY_MOVE(code)   (KC_MS_UP     <= (code) && (code) <= KC_MS_RIGHT)
 #define IS_MOUSEKEY_BUTTON(code) (KC_MS_BTN1   <= (code) && (code) <= KC_MS_BTN5)
@@ -43,13 +41,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define MOD_BIT(code)   (1<<MOD_INDEX(code))
 #define MOD_INDEX(code) ((code) & 0x07)
+// #define FN_BIT(code)    (1<<FN_INDEX(code))
 #define FN_INDEX(code)  ((code) - KC_FN0)
- #define KC_FN_MAX 0xffff
-/* seem to be unused
 #define FN_MIN          KC_FN0
-#define FN_MAX          KC_FN40
-#define FN_BIT(code)    (1<<FN_INDEX(code))
-*/
+#define FN_MAX          0xffff
+
 
 /*
  * Short names for ease of definition of keymap

--- a/tmk_core/common/keycode.h
+++ b/tmk_core/common/keycode.h
@@ -32,7 +32,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define IS_SPECIAL(code)         ((0xA5 <= (code) && (code) <= 0xDF) || (0xE8 <= (code) && (code) <= 0xFF))
 #define IS_SYSTEM(code)          (KC_PWR       <= (code) && (code) <= KC_WAKE)
 #define IS_CONSUMER(code)        (KC_MUTE      <= (code) && (code) <= KC_WFAV)
-#define IS_FN(code)              (KC_FN0       <= (code) && (code) <= KC_FN31)
+/* seems unused
+#define IS_FN(code)              (KC_FN0       <= (code) && (code) <= KC_FN40)
+*/
 #define IS_MOUSEKEY(code)        (KC_MS_UP     <= (code) && (code) <= KC_MS_ACCEL2)
 #define IS_MOUSEKEY_MOVE(code)   (KC_MS_UP     <= (code) && (code) <= KC_MS_RIGHT)
 #define IS_MOUSEKEY_BUTTON(code) (KC_MS_BTN1   <= (code) && (code) <= KC_MS_BTN5)
@@ -41,11 +43,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define MOD_BIT(code)   (1<<MOD_INDEX(code))
 #define MOD_INDEX(code) ((code) & 0x07)
-#define FN_BIT(code)    (1<<FN_INDEX(code))
 #define FN_INDEX(code)  ((code) - KC_FN0)
+ #define KC_FN_MAX 0xffff
+/* seem to be unused
 #define FN_MIN          KC_FN0
-#define FN_MAX          KC_FN31
-
+#define FN_MAX          KC_FN40
+#define FN_BIT(code)    (1<<FN_INDEX(code))
+*/
 
 /*
  * Short names for ease of definition of keymap
@@ -440,41 +444,6 @@ enum internal_special_keycodes {
     /* Jump to bootloader */
     KC_BOOTLOADER       = 0xBF,
 
-    /* Fn key */
-    KC_FN0              = 0xC0,
-    KC_FN1,
-    KC_FN2,
-    KC_FN3,
-    KC_FN4,
-    KC_FN5,
-    KC_FN6,
-    KC_FN7,
-    KC_FN8,
-    KC_FN9,
-    KC_FN10,
-    KC_FN11,
-    KC_FN12,
-    KC_FN13,
-    KC_FN14,
-    KC_FN15,
-
-    KC_FN16             = 0xD0,
-    KC_FN17,
-    KC_FN18,
-    KC_FN19,
-    KC_FN20,
-    KC_FN21,
-    KC_FN22,
-    KC_FN23,
-    KC_FN24,
-    KC_FN25,
-    KC_FN26,
-    KC_FN27,
-    KC_FN28,
-    KC_FN29,
-    KC_FN30,
-    KC_FN31,            /* 0xDF */
-
     /**************************************/
     /* 0xE0-E7 for Modifiers. DO NOT USE. */
     /**************************************/
@@ -497,7 +466,49 @@ enum internal_special_keycodes {
     /* Mousekey accel */
     KC_MS_ACCEL0,
     KC_MS_ACCEL1,
-    KC_MS_ACCEL2        /* 0xFF */
+    KC_MS_ACCEL2,        /* 0xFF */
+        /* Fn key */
+    KC_FN0,
+    KC_FN1,
+    KC_FN2,
+    KC_FN3,
+    KC_FN4,
+    KC_FN5,
+    KC_FN6,
+    KC_FN7,
+    KC_FN8,
+    KC_FN9,
+    KC_FN10,
+    KC_FN11,
+    KC_FN12,
+    KC_FN13,
+    KC_FN14,
+    KC_FN15,
+    KC_FN16,
+    KC_FN17,
+    KC_FN18,
+    KC_FN19,
+    KC_FN20,
+    KC_FN21,
+    KC_FN22,
+    KC_FN23,
+    KC_FN24,
+    KC_FN25,
+    KC_FN26,
+    KC_FN27,
+    KC_FN28,
+    KC_FN29,
+    KC_FN30,
+    KC_FN31,
+    KC_FN32,
+    KC_FN33,
+    KC_FN34,
+    KC_FN35,
+    KC_FN36,
+    KC_FN37,
+    KC_FN38,
+    KC_FN39,
+    KC_FN40,
 };
 
 #endif /* KEYCODE_H */

--- a/tmk_core/common/keymap.c
+++ b/tmk_core/common/keymap.c
@@ -36,7 +36,7 @@ action_t action_for_key(uint8_t layer, keypos_t key)
 {
     uint16_t keycode = keymap_key_to_keycode(layer, key);
     switch (keycode) {
-        case KC_FN0 ... KC_FN_MAX:
+        case KC_FN0 ... FN_MAX:
             return keymap_fn_to_action(keycode);
 #ifdef BOOTMAGIC_ENABLE
         case KC_CAPSLOCK:

--- a/tmk_core/common/keymap.c
+++ b/tmk_core/common/keymap.c
@@ -28,15 +28,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 extern keymap_config_t keymap_config;
 #endif
 
-static action_t keycode_to_action(uint8_t keycode);
+static action_t keycode_to_action(uint16_t keycode);
 
 
 /* converts key to action */
 action_t action_for_key(uint8_t layer, keypos_t key)
 {
-    uint8_t keycode = keymap_key_to_keycode(layer, key);
+    uint16_t keycode = keymap_key_to_keycode(layer, key);
     switch (keycode) {
-        case KC_FN0 ... KC_FN31:
+        case KC_FN0 ... KC_FN_MAX:
             return keymap_fn_to_action(keycode);
 #ifdef BOOTMAGIC_ENABLE
         case KC_CAPSLOCK:
@@ -131,7 +131,7 @@ void action_function(keyrecord_t *record, uint8_t id, uint8_t opt)
 
 
 /* translates keycode to action */
-static action_t keycode_to_action(uint8_t keycode)
+static action_t keycode_to_action(uint16_t keycode)
 {
     action_t action = {};
     switch (keycode) {
@@ -179,11 +179,11 @@ uint8_t keymap_key_to_keycode(uint8_t layer, keypos_t key)
 
 /* Legacy keymap support */
 __attribute__ ((weak))
-action_t keymap_fn_to_action(uint8_t keycode)
+action_t keymap_fn_to_action(uint16_t keycode)
 {
     action_t action = { .code = ACTION_NO };
     switch (keycode) {
-        case KC_FN0 ... KC_FN31:
+        case KC_FN0 ... KC_FN_MAX:
             {
                 uint8_t layer = keymap_fn_layer(FN_INDEX(keycode));
                 uint8_t key = keymap_fn_keycode(FN_INDEX(keycode));

--- a/tmk_core/common/keymap.c
+++ b/tmk_core/common/keymap.c
@@ -179,11 +179,11 @@ uint8_t keymap_key_to_keycode(uint8_t layer, keypos_t key)
 
 /* Legacy keymap support */
 __attribute__ ((weak))
-action_t keymap_fn_to_action(uint16_t keycode)
+action_t keymap_fn_to_action(uint8_t keycode)
 {
     action_t action = { .code = ACTION_NO };
     switch (keycode) {
-        case KC_FN0 ... KC_FN_MAX:
+        case KC_FN0 ... KC_FN31:
             {
                 uint8_t layer = keymap_fn_layer(FN_INDEX(keycode));
                 uint8_t key = keymap_fn_keycode(FN_INDEX(keycode));

--- a/tmk_core/common/keymap.h
+++ b/tmk_core/common/keymap.h
@@ -42,10 +42,10 @@ typedef union {
 
 
 /* translates key to keycode */
-uint8_t keymap_key_to_keycode(uint8_t layer, keypos_t key);
+uint16_t keymap_key_to_keycode(uint8_t layer, keypos_t key);
 
 /* translates Fn keycode to action */
-action_t keymap_fn_to_action(uint8_t keycode);
+action_t keymap_fn_to_action(uint16_t keycode);
 
 
 


### PR DESCRIPTION
My changes enable the support of more than 32 FN keys. You can simply use FN32 and greater in the KEYMAP macro and and set the respective action in the fn_actions array. The changes are quite minimal: I moved the KC_FNxx definitions in keycode.h to the end of the enum, starting with 0x100. Therefore, keycode need to be uint16_t, not uint8_t, which I changed as well.

The code works for me, I'm using a Filco Majestouch 2 with bepiphany's new version of the Kitten Paw controller. Due to a lack of keyboards I'm unable to do more testing.

I defined FN32 to FN40 for testing in tmk_core/common/keycode.h, you would need to put additional keys in here or use numeric values in the KEYMAP.