### PR TITLE
adb_usb/matrix.c : changed size of handler_id from uint16_t to uint8_t

### DIFF
--- a/converter/adb_usb/matrix.c
+++ b/converter/adb_usb/matrix.c
@@ -65,7 +65,7 @@ void matrix_init(void)
 
     // Determine ISO keyboard by handler id
     // http://lxr.free-electrons.com/source/drivers/macintosh/adbhid.c?v=4.4#L815
-    uint16_t handler_id = adb_host_talk(ADB_ADDR_KEYBOARD, ADB_REG_3);
+    uint8_t handler_id = (uint8_t) adb_host_talk(ADB_ADDR_KEYBOARD, ADB_REG_3);
     switch (handler_id) {
     case 0x04: case 0x05: case 0x07: case 0x09: case 0x0D:
     case 0x11: case 0x14: case 0x19: case 0x1D: case 0xC1:


### PR DESCRIPTION
I think I found the cause and a solution for #35 which also happened on my ISO, Canadian Multilingual M3501.

Sample hid_listen output:
```
Waiting for device:.....
Listening:
Before init:
Scan: addr:2, reg3:6505
After init:
Scan: addr:2, reg3:6403
debug enabled.
Keyboard start.
```
With the 05 as expected for an ISO board. From what I could see. the two larger bytes changed from one boot to another.

On another note, I've seen the value return 03 (i.e. ANSI) when resetting and flashing the converter (here: an Arduino Pro Micro clone) without disconnecting for a few seconds.