### PR TITLE
add support for Zenith Z-150 'black label' keyboard

### DIFF
--- a/converter/xt_usb/Makefile
+++ b/converter/xt_usb/Makefile
@@ -71,7 +71,6 @@ F_USB = $(F_CPU)
 #   LUFA bootloader  4096
 #   USBaspLoader     2048
 OPT_DEFS += -DBOOTLOADER_SIZE=512
-#OPT_DEFS += -DBOOTLOADER_SIZE=4096
 
 
 # Build Options

--- a/converter/xt_usb/Makefile
+++ b/converter/xt_usb/Makefile
@@ -71,6 +71,7 @@ F_USB = $(F_CPU)
 #   LUFA bootloader  4096
 #   USBaspLoader     2048
 OPT_DEFS += -DBOOTLOADER_SIZE=512
+#OPT_DEFS += -DBOOTLOADER_SIZE=4096
 
 
 # Build Options
@@ -88,6 +89,10 @@ NKRO_ENABLE = yes	# USB Nkey Rollover
 #
 XT_USE_INT = yes	# uses external interrupt for falling edge of PS/2 clock pin
 
+
+# Various Ornery Keyboard Options
+#
+XT_ZENITH_BLACK = no	# enable code to support Zenith Z-150 "black label" XT, don't enable for regular XT
 
 # Optimize size but this may cause error "relocation truncated to fit"
 #EXTRALDFLAGS = -Wl,--relax

--- a/converter/xt_usb/config.h
+++ b/converter/xt_usb/config.h
@@ -55,10 +55,35 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define XT_DATA_PIN    PIND
 #define XT_DATA_DDR    DDRD
 #define XT_DATA_BIT    0
+/* optional */
+#ifdef XT_ZENITH_BLACK
+#define XT_RST_PORT    PORTB
+#define XT_RST_PIN     PINB
+#define XT_RST_DDR     DDRB
+#define XT_RST_BIT     7
+#define XT_RST_INIT() do { \
+    /* set to low */                  \
+    XT_RST_PORT &= ~(1<<XT_RST_BIT);  \
+    XT_RST_DDR  |=  (1<<XT_RST_BIT);  \
+                                      \
+    /* wait 0.2s */                   \
+    _delay_ms(200);                   \
+                                      \
+    /* pull up */                     \
+    XT_RST_DDR  &= ~(1<<XT_RST_BIT);  \
+    XT_RST_PORT |=  (1<<XT_RST_BIT);  \
+} while (0)
+#endif /* XT_ZENITH_BLACK */
+#ifdef XT_ZENITH_BLACK
+#define XT_INT_INIT()  do {    \
+    EICRA |= (1<<ISC11);       \
+} while (0)
+#else
 #define XT_INT_INIT()  do {    \
     EICRA |= ((1<<ISC11) |      \
               (1<<ISC10));      \
 } while (0)
+#endif /* XT_ZENITH_BLACK */
 #define XT_INT_ON()  do {      \
     EIMSK |= (1<<INT1);         \
 } while (0)

--- a/tmk_core/protocol.mk
+++ b/tmk_core/protocol.mk
@@ -32,6 +32,10 @@ ifeq (yes,$(strip $(XT_USE_INT)))
     OPT_DEFS += -DXT_USE_INT
 endif
 
+ifeq (yes,$(strip $(XT_ZENITH_BLACK)))
+    OPT_DEFS += -DXT_ZENITH_BLACK
+endif
+
 
 ifeq (yes,$(strip $(SERIAL_MOUSE_MICROSOFT_ENABLE)))
     SRC += $(PROTOCOL_DIR)/serial_mouse_microsoft.c

--- a/tmk_core/protocol/xt_interrupt.c
+++ b/tmk_core/protocol/xt_interrupt.c
@@ -52,6 +52,9 @@ void xt_host_init(void)
 {
     XT_INT_INIT();
     XT_INT_ON();
+#ifdef XT_ZENITH_BLACK
+    XT_RST_INIT();
+#endif /* XT_ZENITH_BLACK */
 }
 
 /* get data received by interrupt */
@@ -70,10 +73,14 @@ ISR(XT_INT_VECT)
     static uint8_t data = 0;
 
     if (state == 0) {
+#ifndef XT_ZENITH_BLACK
         if (data_in())
+#endif /* XT_ZENITH_BLACK */
             state++;
     } else if (state >= 1 && state <= 8) {
+#ifndef XT_ZENITH_BLACK
         wait_clock_lo(20);
+#endif /* XT_ZENITH_BLACK */
         data >>= 1;
         if (data_in())
             data |= 0x80;


### PR DESCRIPTION
Hi guys this is a batch of small fixes that I've applied to make the xt_usb converter work with the Z-150 black label.  This keyboard speaks an "XT-like" protocol and requires the reset line to be connected, and works better with the interrupt changes in this patch.  Without these changes, it does not work at all.   It would be great to add this to TMK because I think it would be the only open-source code that supports this keyboard.