### PR TITLE
Fix a name conflict

### DIFF
--- a/tmk_core/common/hook.h
+++ b/tmk_core/common/hook.h
@@ -66,7 +66,7 @@ void hook_default_layer_change(uint32_t default_layer_state);
 
 /* Called on layer state change event. */
 /* Default behaviour: do nothing. */
-void hook_layer_change(uint32_t layer_state);
+void hook_layer_change(uint32_t l_state);
 
 /* Called on indicator LED update event (when reported from host). */
 /* Default behaviour: calls keyboard_set_leds. */


### PR DESCRIPTION
Macro layer_state collided with a function parameter.

Without this fix, onekey doesn't compile if NO_ACTION_LAYER is defined in config.h.