### PR TITLE
Check if default_layer in the EEPROM is not 0

### DIFF
--- a/tmk_core/common/bootmagic.c
+++ b/tmk_core/common/bootmagic.c
@@ -102,11 +102,12 @@ void bootmagic(void)
     if (bootmagic_scan_key(BOOTMAGIC_KEY_DEFAULT_LAYER_5)) { default_layer |= (1<<5); }
     if (bootmagic_scan_key(BOOTMAGIC_KEY_DEFAULT_LAYER_6)) { default_layer |= (1<<6); }
     if (bootmagic_scan_key(BOOTMAGIC_KEY_DEFAULT_LAYER_7)) { default_layer |= (1<<7); }
-    if (default_layer) {
+    uint8_t prev_default_layer = eeconfig_read_default_layer();
+    if (default_layer != prev_default_layer) {
         eeconfig_write_default_layer(default_layer);
         default_layer_set((uint32_t)default_layer);
     } else {
-        default_layer = eeconfig_read_default_layer();
+        default_layer = prev_default_layer;
         default_layer_set((uint32_t)default_layer);
     }
 }


### PR DESCRIPTION
There could be garbage data in the EEPROM, meaning that the default
layer gets set to one that does not exist. This value was not re-set
as the conditional only checked =! 0. We should check to see if it
differs and reset as needed.