### PR TITLE
Don't handle TICK in layer_switch_get_action()

### DIFF
--- a/tmk_core/common/action_layer.c
+++ b/tmk_core/common/action_layer.c
@@ -149,6 +149,8 @@ static uint8_t layer_pressed[MATRIX_ROWS][MATRIX_COLS] = {};
 action_t layer_switch_get_action(keyevent_t event)
 {
     uint8_t layer = 0;
+    if (IS_NOEVENT(event))
+      return (action_t)ACTION_NO;
 #ifndef NO_TRACK_KEY_PRESS
     if (event.pressed) {
         layer = current_layer_for_key(event.key);


### PR DESCRIPTION
TICK is a special event which has a column/row of 255. 
It would lead to an out-of-bounds access in the layer_pressed array which might lead to resets due to hardfaults.

This bug was introduced with commit for the "Modifier/Layer key stuck problem".