### PR TITLE
Move all ChibiOS install documentation to once place

### DIFF
--- a/keyboard/infinity_chibios/MEMO.txt
+++ b/keyboard/infinity_chibios/MEMO.txt
@@ -5,18 +5,7 @@ flabbergast's TMK/ChibiOS port
 
 Build
 -----
-$ git clone -b chibios https://github.com/flabbergast/tmk_keyboard.git
-
-$ cd tmk_keyboard
-$ git submodule add -f -b kinetis https://github.com/flabbergast/ChibiOS.git tmk_core/tool/chibios/chibios
-or
-$ cd tmk_keyboard/tmk_core/tool/chibios
-$ git clone -b kinetis https://github.com/flabbergast/ChibiOS.git tmk_core/tool/chibios/chibios
-
-$ cd tmk_keyboard/keyboard/infinity_chibios
-$ make
-
-
+Set up ChibiOS according to tmk_core/protocol/chibios/README.md
 
 
 Chibios Configuration

--- a/keyboard/teensy_lc_onekey/instructions.md
+++ b/keyboard/teensy_lc_onekey/instructions.md
@@ -2,16 +2,7 @@
 
 These ARM Teensies are now supported through [ChibiOS](http://chibios.org).
 
-You'll need to install an ARM toolchain, for instance from [gcc ARM embedded](https://launchpad.net/gcc-arm-embedded) website, or using your favourite package manager. After installing, you should be able to run `arm-none-eabi-gcc -v` in the command prompt and get sensible output. This toolchain is used instead of `avr-gcc`, which is only for AVR chips. Naturally you'll also need the usual development tools (e.g. `make`), just as in the AVR setting.
-
-Next, you'll need ChibiOS. For Teensies, you'll need code from two repositories: [chibios-main](https://github.com/ChibiOS/ChibiOS) and [chibios-contrib](https://github.com/ChibiOS/ChibiOS-Contrib).
-If you're not using git, you can just download a [zip of chibios from here](https://github.com/ChibiOS/ChibiOS/archive/a7df9a891067621e8e1a5c2a2c0ceada82403afe.zip), unpack the zip, and rename/move the unpacked directory (named `ChibiOS-<long_hash_here>`) to `tmk_core/tool/chibios/ChibiOS` (so that the file `tmk_core/tool/chibios/ChibiOS/license.txt` exists). Now the same procedure with a [zip of chibios-contrib from here](https://github.com/ChibiOS/ChibiOS-Contrib/archive/e1311c4db6cd366cf760673f769e925741ac0ad3.zip): unpack and move `ChibiOS-Contrib-<long_hash_here>` to `tmk_core/tool/chibios/ChibiOS-Contrib`.
-
-If you're using git, you can just clone the two repos inside `tmk_core/tool/chibios`: [chibios](https://github.com/ChibiOS/ChibiOS) and [chibios-contrib](https://github.com/ChibiOS/ChibiOS-Contrib).
-
-(Why do we need chibios-contrib? Well, the main repo focuses on STM32 chips, and Freescale/NXP Kinetis chips are supported via the Contrib repository.)
-
-This should be it.
+Follow the setup instructions in `tmk_core/protocol/chibios/README.md` to install ChibiOS and required toolchain.
 
 Running `make` in `keyboard/teensy_lc_onekey` should create a working firmware in `build/`, called `ch.hex`.
 

--- a/tmk_core/protocol/chibios/README.md
+++ b/tmk_core/protocol/chibios/README.md
@@ -4,9 +4,15 @@ This code can be used to run TMK keyboard logic on top of [ChibiOS], meaning tha
 
 ### Usage
 
-- To use, get a [zip file](https://github.com/ChibiOS/ChibiOS/archive/a7df9a891067621e8e1a5c2a2c0ceada82403afe.zip) of ChibiOS and unpack/rename it to `tmk_core/tool/chibios/ChibiOS`; or you can just clone [ChibiOS repo](https://github.com/ChibiOS/ChibiOS) there. For Freescale/NXP Kinetis support (meaning Teensies 3.x/LC and the Infinity keyboard), you'll also need a [zip](https://github.com/ChibiOS/ChibiOS-Contrib/archive/e1311c4db6cd366cf760673f769e925741ac0ad3.zip) of ChibiOS-Contrib, unpacked/renamed to `tmk_core/tool/chibios/ChibiOS-Contrib`. Likewise, for git-savvy people, just clone [ChibiOS-Contrib repo](https://github.com/ChibiOS/ChibiOS-Contrib) there.
-- Note: the above mentioned directories are the defaults. You can have the two ChibiOS repositories wherever you want, just define their location in `CHIBIOS` and `CHIBIOS_CONTRIB` variables in your `Makefile`.
-- You will also need to install an ARM toolchain, for instance from [here](https://launchpad.net/gcc-arm-embedded). On linux, this is usually also present as a package for your distribution (as `gcc-arm` or something similar). On OS X, you can use [homebrew](http://brew.sh/) with an appropriate tap.
+- To use, get a [zip file](https://github.com/ChibiOS/ChibiOS/archive/stable_17.6.x.zip) of ChibiOS and unpack/rename it to `tmk_core/tool/chibios/ChibiOS`; or you can just clone [ChibiOS/ChibiOS](https://github.com/ChibiOS/ChibiOS) there.
+If you use git, make sure to check out the most recent stable branch such as `stable_17.6.x`
+For Freescale/NXP Kinetis support (meaning Teensies 3.x/LC and the Infinity keyboard), you'll also need a [zip](https://github.com/ChibiOS/ChibiOS-Contrib/archive/master.zip) of ChibiOS-Contrib, unpacked/renamed to `tmk_core/tool/chibios/ChibiOS-Contrib`.
+Likewise, for git-savvy people, just clone [ChibiOS/ChibiOS-Contrib](https://github.com/ChibiOS/ChibiOS-Contrib) there.
+- Note: the above mentioned directories are the defaults.
+You can have the two ChibiOS repositories wherever you want, just define their location in `CHIBIOS` and `CHIBIOS_CONTRIB` variables in your `Makefile`.
+- You will also need to install an ARM toolchain, for instance from [here](https://launchpad.net/gcc-arm-embedded).
+On linux, this is usually also present as a package for your distribution (as `gcc-arm` or something similar).
+On OS X, you can use [homebrew](http://brew.sh/) with an appropriate tap.
 
 ### Notes
 


### PR DESCRIPTION
Moved all install documentation to `tmk_core/protocol/chibios/README.md` from both
- `keyboard/teensy_lc_onekey/instructions.md`
- `keyboard/infinity_chibios/MEMO.txt`

Tells people to check out the most recent stable version of [ChibiOS/ChibiOS](https://github.com/ChibiOS/ChibiOS), and changes the zip download to the branch `stable_17.6.x` from commit `a7df9a891067621e8e1a5c2a2c0ceada82403afe`

Also changed the zip download for [ChibiOS/ChibiOS-Contrib](https://github.com/ChibiOS/ChibiOS-Contrib) to master from commit `e1311c4db6cd366cf760673f769e925741ac0ad3`


From discussion in issue #490