### PR TITLE
core: Fix for unused function when compiling without MOUSEKEY_ENABLE

### DIFF
--- a/tmk_core/common/command.c
+++ b/tmk_core/common/command.c
@@ -57,9 +57,10 @@ static void command_console_help(void);
 #ifdef MOUSEKEY_ENABLE
 static bool mousekey_console(uint8_t code);
 static void mousekey_console_help(void);
+static uint8_t numkey2num(uint8_t code);
 #endif
 
-static uint8_t numkey2num(uint8_t code);
+
 static void switch_default_layer(uint8_t layer);
 
 

--- a/tmk_core/common/command.c
+++ b/tmk_core/common/command.c
@@ -629,6 +629,7 @@ static bool mousekey_console(uint8_t code)
 /***********************************************************
  * Utilities
  ***********************************************************/
+#if MOUSEKEY_ENABLE
 static uint8_t numkey2num(uint8_t code)
 {
     switch (code) {
@@ -645,6 +646,7 @@ static uint8_t numkey2num(uint8_t code)
     }
     return 0;
 }
+#endif
 
 static void switch_default_layer(uint8_t layer)
 {


### PR DESCRIPTION
Gives a compile warning. Fixed it by adding an #if