### PR TITLE
core: Improved performance, fixed nuances in timing

### DIFF
--- a/tmk_core/common/keyboard.c
+++ b/tmk_core/common/keyboard.c
@@ -126,17 +126,18 @@ void keyboard_task(void)
             matrix_ghost[r] = matrix_row;
 #endif
             if (debug_matrix) matrix_print();
-            for (uint8_t c = 0; c < MATRIX_COLS; c++) {
-                if (matrix_change & ((matrix_row_t)1<<c)) {
+            matrix_row_t col_mask = 1;
+            for (uint8_t c = 0; c < MATRIX_COLS; c++, col_mask <<= 1) {
+                if (matrix_change & col_mask) {
                     keyevent_t e = (keyevent_t){
                         .key = (keypos_t){ .row = r, .col = c },
-                        .pressed = (matrix_row & ((matrix_row_t)1<<c)),
+                        .pressed = (matrix_row & col_mask),
                         .time = (timer_read() | 1) /* time should not be 0 */
                     };
                     action_exec(e);
                     hook_matrix_change(e);
                     // record a processed key
-                    matrix_prev[r] ^= ((matrix_row_t)1<<c);
+                    matrix_prev[r] ^= col_mask;
 
                     // This can miss stroke when scan matrix takes long like Topre
                     // process a key per task call


### PR DESCRIPTION
* Fixed a bug where the time reported for keys inside a matrix scan would be different if the clock ticked halfway through scanning. 
* Improved performance by caching timer_read() and the col_mask rather than calculating them multiple times.