### PR TITLE
User Definable NUM_LAYERS. Builds upon layer_state_t

### DIFF
--- a/keyboard/fc660c/unimap_emu.c
+++ b/keyboard/fc660c/unimap_emu.c
@@ -54,7 +54,7 @@ const action_t actionmaps[][UNIMAP_ROWS][UNIMAP_COLS] PROGMEM = {
 };
 
 
-void hook_layer_change(uint32_t layer_state)
+void hook_layer_change(layer_state_t layer_state)
 {
     // lights LED on Insert when layer 1 is enabled
     if (layer_state & (1L<<1)) {

--- a/keyboard/fc660c/unimap_hasu.c
+++ b/keyboard/fc660c/unimap_hasu.c
@@ -73,7 +73,7 @@ const action_t actionmaps[][UNIMAP_ROWS][UNIMAP_COLS] PROGMEM = {
 };
 
 
-void hook_layer_change(uint32_t layer_state)
+void hook_layer_change(layer_state_t layer_state)
 {
     // lights LED on Insert when layer 1 is enabled
     if (layer_state & (1L<<1)) {

--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -218,8 +218,8 @@ void process_action(keyrecord_t *record)
                 /* Default Layer Bitwise Operation */
                 if (!event.pressed) {
                     uint8_t shift = action.layer_bitop.part*4;
-                    uint32_t bits = ((uint32_t)action.layer_bitop.bits)<<shift;
-                    uint32_t mask = (action.layer_bitop.xbit) ? ~(((uint32_t)0xf)<<shift) : 0;
+                    layer_state_t bits = ((layer_state_t)action.layer_bitop.bits)<<shift;
+                    layer_state_t mask = (action.layer_bitop.xbit) ? ~(((layer_state_t)0xf)<<shift) : 0;
                     switch (action.layer_bitop.op) {
                         case OP_BIT_AND: default_layer_and(bits | mask); break;
                         case OP_BIT_OR:  default_layer_or(bits | mask);  break;
@@ -232,8 +232,8 @@ void process_action(keyrecord_t *record)
                 if (event.pressed ? (action.layer_bitop.on & ON_PRESS) :
                                     (action.layer_bitop.on & ON_RELEASE)) {
                     uint8_t shift = action.layer_bitop.part*4;
-                    uint32_t bits = ((uint32_t)action.layer_bitop.bits)<<shift;
-                    uint32_t mask = (action.layer_bitop.xbit) ? ~(((uint32_t)0xf)<<shift) : 0;
+                    layer_state_t bits = ((layer_state_t)action.layer_bitop.bits)<<shift;
+                    layer_state_t mask = (action.layer_bitop.xbit) ? ~(((layer_state_t)0xf)<<shift) : 0;
                     switch (action.layer_bitop.op) {
                         case OP_BIT_AND: layer_and(bits | mask); break;
                         case OP_BIT_OR:  layer_or(bits | mask);  break;

--- a/tmk_core/common/action_layer.c
+++ b/tmk_core/common/action_layer.c
@@ -5,6 +5,7 @@
 #include "action_layer.h"
 #include "hook.h"
 
+#include "action_layer.h"
 #ifdef DEBUG_ACTION
 #include "debug.h"
 #else
@@ -126,7 +127,7 @@ static uint8_t current_layer_for_key(keypos_t key)
     action_t action = ACTION_TRANSPARENT;
     layer_state_t layers = layer_state | default_layer_state;
     /* check top layer first */
-    for (int8_t i = 31; i >= 0; i--) {
+    for (int8_t i = NUM_LAYERS-1; i >= 0; i--) {
         if (layers & (1UL<<i)) {
             action = action_for_key(i, key);
             if (action.code != (action_t)ACTION_TRANSPARENT.code) {

--- a/tmk_core/common/action_layer.c
+++ b/tmk_core/common/action_layer.c
@@ -5,7 +5,6 @@
 #include "action_layer.h"
 #include "hook.h"
 
-#include "action_layer.h"
 #ifdef DEBUG_ACTION
 #include "debug.h"
 #else
@@ -61,6 +60,7 @@ void default_layer_xor(layer_state_t state)
  * Keymap Layer State
  */
 layer_state_t layer_state = 0;
+static const layer_state_t ONE = ((layer_state_t)1);
 
 static void layer_state_set(layer_state_t state)
 {
@@ -81,22 +81,22 @@ void layer_clear(void)
 
 void layer_move(uint8_t layer)
 {
-    layer_state_set(1UL<<layer);
+    layer_state_set(ONE<<layer);
 }
 
 void layer_on(uint8_t layer)
 {
-    layer_state_set(layer_state | (1UL<<layer));
+    layer_state_set(layer_state | (ONE<<layer));
 }
 
 void layer_off(uint8_t layer)
 {
-    layer_state_set(layer_state & ~(1UL<<layer));
+    layer_state_set(layer_state & ~(ONE<<layer));
 }
 
 void layer_invert(uint8_t layer)
 {
-    layer_state_set(layer_state ^ (1UL<<layer));
+    layer_state_set(layer_state ^ (ONE<<layer));
 }
 
 void layer_or(layer_state_t state)
@@ -123,12 +123,12 @@ void layer_debug(void)
 /* return layer effective for key at this time */
 static uint8_t current_layer_for_key(keypos_t key)
 {
-#ifndef NO_ACTION_LAYER
+#ifndef NO_ACTION_LAYER    
     action_t action = ACTION_TRANSPARENT;
     layer_state_t layers = layer_state | default_layer_state;
     /* check top layer first */
     for (int8_t i = NUM_LAYERS-1; i >= 0; i--) {
-        if (layers & (1UL<<i)) {
+        if (layers & (ONE<<i)) {
             action = action_for_key(i, key);
             if (action.code != (action_t)ACTION_TRANSPARENT.code) {
                 return i;

--- a/tmk_core/common/action_layer.c
+++ b/tmk_core/common/action_layer.c
@@ -15,9 +15,9 @@
 /* 
  * Default Layer State
  */
-uint32_t default_layer_state = 0;
+layer_state_t default_layer_state = 0;
 
-static void default_layer_state_set(uint32_t state)
+static void default_layer_state_set(layer_state_t state)
 {
     debug("default_layer_state: ");
     default_layer_debug(); debug(" to ");
@@ -34,21 +34,21 @@ void default_layer_debug(void)
     dprintf("%08lX(%u)", default_layer_state, biton32(default_layer_state));
 }
 
-void default_layer_set(uint32_t state)
+void default_layer_set(layer_state_t state)
 {
     default_layer_state_set(state);
 }
 
 #ifndef NO_ACTION_LAYER
-void default_layer_or(uint32_t state)
+void default_layer_or(layer_state_t state)
 {
     default_layer_state_set(default_layer_state | state);
 }
-void default_layer_and(uint32_t state)
+void default_layer_and(layer_state_t state)
 {
     default_layer_state_set(default_layer_state & state);
 }
-void default_layer_xor(uint32_t state)
+void default_layer_xor(layer_state_t state)
 {
     default_layer_state_set(default_layer_state ^ state);
 }
@@ -59,9 +59,9 @@ void default_layer_xor(uint32_t state)
 /* 
  * Keymap Layer State
  */
-uint32_t layer_state = 0;
+layer_state_t layer_state = 0;
 
-static void layer_state_set(uint32_t state)
+static void layer_state_set(layer_state_t state)
 {
     dprint("layer_state: ");
     layer_debug(); dprint(" to ");
@@ -98,15 +98,15 @@ void layer_invert(uint8_t layer)
     layer_state_set(layer_state ^ (1UL<<layer));
 }
 
-void layer_or(uint32_t state)
+void layer_or(layer_state_t state)
 {
     layer_state_set(layer_state | state);
 }
-void layer_and(uint32_t state)
+void layer_and(layer_state_t state)
 {
     layer_state_set(layer_state & state);
 }
-void layer_xor(uint32_t state)
+void layer_xor(layer_state_t state)
 {
     layer_state_set(layer_state ^ state);
 }
@@ -124,7 +124,7 @@ static uint8_t current_layer_for_key(keypos_t key)
 {
 #ifndef NO_ACTION_LAYER
     action_t action = ACTION_TRANSPARENT;
-    uint32_t layers = layer_state | default_layer_state;
+    layer_state_t layers = layer_state | default_layer_state;
     /* check top layer first */
     for (int8_t i = 31; i >= 0; i--) {
         if (layers & (1UL<<i)) {

--- a/tmk_core/common/action_layer.h
+++ b/tmk_core/common/action_layer.h
@@ -21,7 +21,20 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "keyboard.h"
 #include "action.h"
 
-typedef uint32_t layer_state_t;
+#ifndef NUM_LAYERS //You can redefine NUM_LAYERS in config.h to improve performance.
+    #define NUM_LAYERS 32
+#endif
+
+#if (NUM_LAYERS <= 8)
+typedef  uint8_t    layer_state_t;
+#elif (NUM_LAYERS <= 16)
+typedef  uint16_t   layer_state_t;
+#elif (NUM_LAYERS <= 32)
+typedef  uint32_t   layer_state_t;
+#else 
+//Note we can't have more than 32 layers due to implementation of action_code.action_layer.bitop
+#error "NUM_LAYERS: invalid value"
+#endif
 
 /*
  * Default Layer

--- a/tmk_core/common/action_layer.h
+++ b/tmk_core/common/action_layer.h
@@ -21,19 +21,20 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "keyboard.h"
 #include "action.h"
 
+typedef uint32_t layer_state_t;
 
 /*
  * Default Layer
  */
-extern uint32_t default_layer_state;
+extern layer_state_t default_layer_state;
 void default_layer_debug(void);
-void default_layer_set(uint32_t state);
+void default_layer_set(layer_state_t state);
 
 #ifndef NO_ACTION_LAYER
 /* bitwise operation */
-void default_layer_or(uint32_t state);
-void default_layer_and(uint32_t state);
-void default_layer_xor(uint32_t state);
+void default_layer_or(layer_state_t state);
+void default_layer_and(layer_state_t state);
+void default_layer_xor(layer_state_t state);
 #endif
 
 
@@ -41,7 +42,7 @@ void default_layer_xor(uint32_t state);
  * Keymap Layer
  */
 #ifndef NO_ACTION_LAYER
-extern uint32_t layer_state;
+extern layer_state_t layer_state;
 void layer_debug(void);
 void layer_clear(void);
 void layer_move(uint8_t layer);
@@ -49,9 +50,9 @@ void layer_on(uint8_t layer);
 void layer_off(uint8_t layer);
 void layer_invert(uint8_t layer);
 /* bitwise operation */
-void layer_or(uint32_t state);
-void layer_and(uint32_t state);
-void layer_xor(uint32_t state);
+void layer_or(layer_state_t state);
+void layer_and(layer_state_t state);
+void layer_xor(layer_state_t state);
 #endif
 
 

--- a/tmk_core/common/bootmagic.c
+++ b/tmk_core/common/bootmagic.c
@@ -104,10 +104,10 @@ void bootmagic(void)
     if (bootmagic_scan_key(BOOTMAGIC_KEY_DEFAULT_LAYER_7)) { default_layer |= (1<<7); }
     if (default_layer) {
         eeconfig_write_default_layer(default_layer);
-        default_layer_set((uint32_t)default_layer);
+        default_layer_set((layer_state_t)default_layer);
     } else {
         default_layer = eeconfig_read_default_layer();
-        default_layer_set((uint32_t)default_layer);
+        default_layer_set((layer_state_t)default_layer);
     }
 }
 

--- a/tmk_core/common/hook.c
+++ b/tmk_core/common/hook.c
@@ -31,12 +31,12 @@ void hook_matrix_change(keyevent_t event) {
 }
 
 __attribute__((weak))
-void hook_default_layer_change(uint32_t default_layer_state) {
+void hook_default_layer_change(layer_state_t default_layer_state) {
     (void)default_layer_state;
 }
 
 __attribute__((weak))
-void hook_layer_change(uint32_t layer_state) {
+void hook_layer_change(layer_state_t layer_state) {
     (void)layer_state;
 }
 

--- a/tmk_core/common/hook.h
+++ b/tmk_core/common/hook.h
@@ -19,6 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define _HOOKS_H_
 
 #include "keyboard.h"
+#include "action_layer.h"
 #include "led.h"
 
 /* -------------------------------------
@@ -62,11 +63,11 @@ void hook_matrix_change(keyevent_t event);
 
 /* Called on default layer state change event. */
 /* Default behaviour: do nothing. */
-void hook_default_layer_change(uint32_t default_layer_state);
+void hook_default_layer_change(layer_state_t default_layer_state);
 
 /* Called on layer state change event. */
 /* Default behaviour: do nothing. */
-void hook_layer_change(uint32_t layer_state);
+void hook_layer_change(layer_state_t layer_state);
 
 /* Called on indicator LED update event (when reported from host). */
 /* Default behaviour: calls keyboard_set_leds. */

--- a/tmk_core/doc/hook.txt
+++ b/tmk_core/doc/hook.txt
@@ -14,8 +14,8 @@ Hook function                   | Timing
 `hook_usb_suspend_loop(void)`   | Continuously, while the device is in USB suspend state. *Default action:* power down and periodically check the matrix, causing wakeup if needed.
 `hook_keyboard_loop(void)`      | Continuously, during the main loop, after the matrix is checked.
 `hook_matrix_change(keyevent_t event)`      | When a matrix state change is detected, before any other actions are processed.
-`hook_layer_change(uint32_t layer_state)`   | When any layer is changed.
-`hook_default_layer_change(uint32_t default_layer_state)`   | When any default layer is changed.
+`hook_layer_change(layer_state_t layer_state)`   | When any layer is changed.
+`hook_default_layer_change(layer_state_t default_layer_state)`   | When any default layer is changed.
 `hook_keyboard_leds_change(uint8_t led_status)`             | Whenever a change in the LED status is performed. *Default action:* call `keyboard_set_leds(led_status)`
 
 

--- a/tmk_core/doc/keymap.md
+++ b/tmk_core/doc/keymap.md
@@ -387,9 +387,9 @@ bs
 
 These parameters works as following code.
 
-    uint32_t layer_state;
+    layer_state_t layer_state;
     uint8_t shift = part*4;
-    uint32_t mask = (bits&0x10) ? ~((uint32_t)0xf<<shift) : 0;
+    layer_state_t mask = (bits&0x10) ? ~((layer_state_t)0xf<<shift) : 0;
     switch (<bitop>) {
     case BIT_AND:
         layer_state = layer_state & (((bits&0xf)<<shift)|mask);


### PR DESCRIPTION
Users can now define NUM_LAYERS. 
I haven't yet tested:
```
#if NUM_LAYERS > 16   // layer_state is uint32_t
    return action.layer_bitop.part*4;
#elif NUM_LAYERS > 8   // unit16_t
    return (action.layer_bitop.part & 3)*4;
#else  // uint8_t
    return (action.layer_bitop.part & 1)*4;
#endif
```

* Major space saving from using uint8_t instead of uint32_t, on the order of 300+ bytes.
* Minor time saving for all the bitshifts.

TODO: define constant "Layer_size_ONE" as ((layer_state_t)1) for all bitshifting everywhere.