### PR TITLE
core: Add utility macros in action_macro.h

### DIFF
--- a/tmk_core/common/action_macro.h
+++ b/tmk_core/common/action_macro.h
@@ -105,6 +105,19 @@ enum macro_command_id{
 #define RM()            RESTORE()
 /* clear modifier(s) */
 #define CM()            CLEAR()
+/* key shift-type */
+#define ST(key)         D(LSFT),    T(key),   U(LSFT)
+/* modifier utility macros */
+/*      Example: Ctrl+Alt+[Shift+]<key1,key2> is CTL_( ALT_( [S]T(key1), [S]T(key2) )) . */
+#define SFT_(...)       D(LSFT), __VA_ARGS__, U(LSFT)
+#define CTL_(...)       D(LCTL), __VA_ARGS__, U(LCTL)
+#define ALT_(...)       D(LALT), __VA_ARGS__, U(LALT)
+#define AGR_(...)       D(RALT), __VA_ARGS__, U(RALT)
+/* Unicode macros for XOrg/MacOs/Win. */
+/*      Example: UNIW_(0,1,4,9) enters a bullet glyph on Windows using Alt+KeyPad(####). */
+#define UNIX_(d1,d2,d3,d4)  CTL_(ST(U)),    T(d1), T(d2), T(d3), T(d4)      , T(ENT)
+#define UNIM_(d1,d2,d3,d4)  ALT_(           T(d1), T(d2), T(d3), T(d4)      )
+#define UNIW_(d1,d2,d3,d4)  ALT_( T(P##d1), T(P##d2), T(P##d3), T(P##d4)    )
 
 /* for backward comaptibility */
 #define MD(key)         DOWN(KC_##key)


### PR DESCRIPTION

* Macro definitions for typing modified keys more easily in TMK macros.
    - Example: Ctrl+Alt+[Shift+]<key> can be entered with CTL_( ALT_( [S]T(key) ))
    - AGR_ is for RAlt/AltGr input, useful with international system layouts.
* Macro definitions for typing OS specific Unicode input.
    * For XOrg,    Unicode 4-digit hex input uses Ctrl+Shift+u, ####, Enter.
    * For MacOS,   Unicode 4-digit hex Unicode input uses Alt+#### (as Alt equals Mac Option).
    * For Windows, Unicode 4-digit decimal nr. input uses Alt+Keypad(####).
