### PR TITLE
Implement `layer_switch` function in `action.c`

### DIFF
--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -535,6 +535,10 @@ void clear_keyboard_but_mods(void)
 #endif
 }
 
+void layer_switch(uint8_t new_layer) {
+    layer_move(new_layer);
+}
+
 bool is_tap_key(keyevent_t event)
 {
     if (IS_NOEVENT(event)) { return false; }


### PR DESCRIPTION
`layer_switch` exists in `action.h` but is not actually implemented anywhere.