### PR TITLE
core: improve timing in ps2_host_send to fix caps/num LEDs consistency

### DIFF
--- a/tmk_core/protocol/ps2_busywait.c
+++ b/tmk_core/protocol/ps2_busywait.c
@@ -73,6 +73,9 @@ uint8_t ps2_host_send(uint8_t data)
     bool parity = true;
     ps2_error = PS2_ERR_NONE;
 
+    // see http://www.burtonsys.com/ps2_chapweske.htm but note that
+    // sending host->device samples on the rising not falling CLK edge
+
     /* terminate a transmission if we have */
     inhibit();
     wait_us(100); // 100us [4]p.13, [5]p.50
@@ -84,7 +87,6 @@ uint8_t ps2_host_send(uint8_t data)
 
     /* Data bit */
     for (uint8_t i = 0; i < 8; i++) {
-        wait_us(15);
         if (data&(1<<i)) {
             parity = !parity;
             data_hi();
@@ -92,17 +94,16 @@ uint8_t ps2_host_send(uint8_t data)
             data_lo();
         }
         WAIT(clock_hi, 50, 2);
+        // keyboard sampled the data, just before here, just as the clock goes high
         WAIT(clock_lo, 50, 3);
     }
 
     /* Parity bit */
-    wait_us(15);
     if (parity) { data_hi(); } else { data_lo(); }
     WAIT(clock_hi, 50, 4);
     WAIT(clock_lo, 50, 5);
 
     /* Stop bit */
-    wait_us(15);
     data_hi();
 
     /* Ack */

--- a/tmk_core/protocol/ps2_interrupt.c
+++ b/tmk_core/protocol/ps2_interrupt.c
@@ -72,6 +72,9 @@ uint8_t ps2_host_send(uint8_t data)
     bool parity = true;
     ps2_error = PS2_ERR_NONE;
 
+    // see http://www.burtonsys.com/ps2_chapweske.htm but note that
+    // sending host->device samples on the rising not falling CLK edge
+
     PS2_INT_OFF();
 
     /* terminate a transmission if we have */
@@ -85,7 +88,6 @@ uint8_t ps2_host_send(uint8_t data)
 
     /* Data bit[2-9] */
     for (uint8_t i = 0; i < 8; i++) {
-        _delay_us(15);
         if (data&(1<<i)) {
             parity = !parity;
             data_hi();
@@ -93,17 +95,16 @@ uint8_t ps2_host_send(uint8_t data)
             data_lo();
         }
         WAIT(clock_hi, 50, 2);
+        // keyboard sampled the data, just before here, just as the clock goes high
         WAIT(clock_lo, 50, 3);
     }
 
     /* Parity bit */
-    _delay_us(15);
     if (parity) { data_hi(); } else { data_lo(); }
     WAIT(clock_hi, 50, 4);
     WAIT(clock_lo, 50, 5);
 
     /* Stop bit */
-    _delay_us(15);
     data_hi();
 
     /* Ack */

--- a/tmk_core/protocol/ps2_usart.c
+++ b/tmk_core/protocol/ps2_usart.c
@@ -78,6 +78,9 @@ uint8_t ps2_host_send(uint8_t data)
     bool parity = true;
     ps2_error = PS2_ERR_NONE;
 
+    // see http://www.burtonsys.com/ps2_chapweske.htm but note that
+    // sending host->device samples on the rising not falling CLK edge
+
     PS2_USART_OFF();
 
     /* terminate a transmission if we have */
@@ -91,7 +94,6 @@ uint8_t ps2_host_send(uint8_t data)
 
     /* Data bit[2-9] */
     for (uint8_t i = 0; i < 8; i++) {
-        _delay_us(15);
         if (data&(1<<i)) {
             parity = !parity;
             data_hi();
@@ -99,17 +101,16 @@ uint8_t ps2_host_send(uint8_t data)
             data_lo();
         }
         WAIT(clock_hi, 50, 2);
+        // keyboard sampled the data, just before here, just as the clock goes high
         WAIT(clock_lo, 50, 3);
     }
 
     /* Parity bit */
-    _delay_us(15);
     if (parity) { data_hi(); } else { data_lo(); }
     WAIT(clock_hi, 50, 4);
     WAIT(clock_lo, 50, 5);
 
     /* Stop bit */
-    _delay_us(15);
     data_hi();
 
     /* Ack */


### PR DESCRIPTION
Thanks for the great project. Typing this on a QPAD MK-80 over USB having both lost their PS/2 to USB adapter and failed to be happy with cheap active adapters not working on both Linux and Mac.

Anyway, I had a problem with the Caps Lock, Number Lock LEDs not being set correctly and the keyboard resetting itself when running on an 8MHz avr pro micro (32u4). Changing the pull-up resistors helped, but given what is said here: http://www.burtonsys.com/ps2_chapweske.htm that the data from host->keyboard is sampled on the rising CLK edge (cf falling edge) then removing the delay would seem appropriate. It could even be done differently, setting the data up just after the WAIT(clock_hi...) ?

I'll own up and say I've only tested this in interrupt mode (pro micro) and only on two PS/2 keyboards - the QPAD MK-80 and an old Chicony KB-5916. The Chicony would also lose some setting of the LEDs before, now both are solid.