### PR TITLE
xt_usb: read on rising or falling edge of clock line

### DIFF
--- a/converter/xt_usb/config.h
+++ b/converter/xt_usb/config.h
@@ -58,6 +58,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define XT_RST_DDR     DDRB
 #define XT_RST_BIT     7
 
+/*
+ * Uncomment to read on the falling edge of the clock signal. Some keyboards 
+ * only work when reading on the rising edge (original IBM XT Keyboard), whereas
+ * others require reading on the falling edge (Microtech made in Brazil, AT2XT 
+ * Converter).
+ */
+// #define XT_READ_ON_FALLING_EDGE
+
 /* hard reset: low pulse for 500ms and after that HiZ for safety */
 #define XT_RESET() do { \
     XT_RST_PORT &= ~(1<<XT_RST_BIT);  \
@@ -66,11 +74,18 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     XT_RST_DDR  &= ~(1<<XT_RST_BIT);  \
 } while (0)
 
-/* INT1 for falling edge of clock line */
-#define XT_INT_INIT()  do {    \
-    EICRA |= ((1<<ISC11) |      \
-              (0<<ISC10));      \
-} while (0)
+/* INT1 for rising or falling edge of clock line. */
+#ifdef XT_READ_ON_FALLING_EDGE
+    #define XT_INT_INIT()  do {    \
+        EICRA |= ((1<<ISC11) |      \
+                  (0<<ISC10));      \
+    } while (0)
+#else
+    #define XT_INT_INIT()  do {    \
+        EICRA |= ((1<<ISC11) |      \
+                  (1<<ISC10));      \
+    } while (0)
+#endif
 /* clears flag and enables interrupt */
 #define XT_INT_ON()  do {      \
     EIFR  |= (1<<INTF1);        \


### PR DESCRIPTION
You can now configure whether your keyboard sends data on a falling or
rising edge of the clock signal.

Specs indicate that the data line should be read on the falling edge of
the clock line. My own testing with an original Model F keyboard however
indicates that this leads to misread scancodes, which can be fixed by
reading on the rising edge. Others have reported the same, and it
appears that Soarer's converter (which works well on my Model F) also
reads on a rising edge.

Why this observed behaviour deviates from the specs is a mystery to me. Making this configurable should at least ensure that most XT keyboards work until a better fix comes along.

Early TMK commit that used rising edge: https://github.com/tmk/tmk_keyboard/pull/355/commits/5cbc226addd2983076aae47611491c96b92d0344

Rationale for that commit: https://deskthority.net/keyboards-f2/tmk-firmware-for-xt-keyboards-t13847.html

I suspect that the behaviour reported here may also be caused by reading on the falling edge: https://github.com/tmk/tmk_keyboard/issues/552#issuecomment-384537581