### PR TITLE
Add missing parentheses to progmem macros (fixes #585)

### DIFF
--- a/tmk_core/common/progmem.h
+++ b/tmk_core/common/progmem.h
@@ -5,8 +5,8 @@
 #   include <avr/pgmspace.h>
 #elif defined(__arm__)
 #   define PROGMEM
-#   define pgm_read_byte(p)     *((unsigned char*)p)
-#   define pgm_read_word(p)     *((uint16_t*)p)
+#   define pgm_read_byte(p)     *((unsigned char*)(p))
+#   define pgm_read_word(p)     *((uint16_t*)(p))
 #endif
 
 #endif


### PR DESCRIPTION
This fixes the parenthesis issue in `progmem.h` that was mentioned in #585. However, the issue might be present in other macros throughout the codebase.