### PR TITLE
Correct the comments of matrix ROW and COL.

### DIFF
--- a/converter/terminal_usb/config.h
+++ b/converter/terminal_usb/config.h
@@ -28,8 +28,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
 /* matrix size */
-#define MATRIX_ROWS 17  // keycode bit: 3-0
-#define MATRIX_COLS 8   // keycode bit: 6-4
+#define MATRIX_ROWS 17  // keycode bit: 7-3
+#define MATRIX_COLS 8   // keycode bit: 2-0
 
 
 /* legacy keymap support */


### PR DESCRIPTION
according to the code:
static uint8_t matrix[MATRIX_ROWS];
#define ROW(code)      (code>>3)
#define COL(code) (code&0x07)
in converter/terminal_usb/matrix.c
ROW is decided by bits 7-4 of scancode
COL is decided by bits 2-0 of scancode