### PR TITLE
Add z62

### DIFF
--- a/keyboard/gh60/Makefile
+++ b/keyboard/gh60/Makefile
@@ -40,7 +40,7 @@
 
 # Target file name (without extension).
 TARGET = gh60_lufa
-
+KEYMAP = z62
 # Directory common source filess exist
 TMK_DIR = ../../tmk_core
 

--- a/keyboard/gh60/keymap_common.h
+++ b/keyboard/gh60/keymap_common.h
@@ -76,4 +76,20 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     K40, K41, K42,           K45,                K49, K4A, K4B, K4C, K4D  \
 )
 
+/* ANSI variant with splitted spacebar into two halves. */
+#define KEYMAP_Z62( \
+    K00, K01, K02, K03, K04, K05, K06, K07, K08, K09, K0A, K0B, K0C, K0D, \
+    K10, K11, K12, K13, K14, K15, K16, K17, K18, K19, K1A, K1B, K1C, K1D, \
+    K20, K21, K22, K23, K24, K25, K26, K27, K28, K29, K2A, K2B,      K2D, \
+    K30, K32, K33, K34, K35, K36, K37, K38, K39, K3A, K3B,           K3D, \
+    K40, K41, K42,           K45,                K49, K4A, K4B, K4C, K4D  \
+)  KEYMAP( \
+    K00, K01, K02, K03, K04, K05, K06, K07, K08, K09, K0A, K0B, K0C, K0D, \
+    K10, K11, K12, K13, K14, K15, K16, K17, K18, K19, K1A, K1B, K1C, K1D, \
+    K20, K21, K22, K23, K24, K25, K26, K27, K28, K29, K2A, K2B, NO,  K2D, \
+    K30, NO,  K32, K33, K34, K35, K36, K37, K38, K39, K3A, K3B, NO,  K3D, \
+    K40, K41, K42,           K45,                K49, K4A, K4B, K4C, K4D  \
+)
+
+
 #endif

--- a/keyboard/gh60/keymap_z62.c
+++ b/keyboard/gh60/keymap_z62.c
@@ -1,0 +1,54 @@
+#include "keymap_common.h"
+
+/*
+ * SpaceFN
+ * http://geekhack.org/index.php?topic=51069.0
+ */
+const uint8_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    /* Keymap 0: Default Layer
+     * ,-----------------------------------------------------------.
+     * |Esc|  1|  2|  3|  4|  5|  6|  7|  8|  9|  0|  -|  =|Backsp |
+     * |-----------------------------------------------------------|
+     * |Tab  |  Q|  W|  E|  R|  T|  Y|  U|  I|  O|  P|  [|  ]|    \|
+     * |-----------------------------------------------------------|
+     * |Caps  |  A|  S|  D|  F|  G|  H|  J|  K|  L|  ;|  '|Return  |
+     * |-----------------------------------------------------------|
+     * |Shift   |  Z|  X|  C|  V|  B|  N|  M|  ,|  .|  /|Shift     |
+     * |-----------------------------------------------------------|
+     * |Ctrl|Gui |Alt |  FN0      |    Space   |Alt |Gui |App |Ctrl|
+     * `-----------------------------------------------------------'
+     */
+    KEYMAP_Z62(
+        ESC, 1,   2,   3,   4,   5,   6,   7,   8,   9,   0,   MINS,EQL, BSPC, \
+        TAB, Q,   W,   E,   R,   T,   Y,   U,   I,   O,   P,   LBRC,RBRC,BSLS, \
+        CAPS,A,   S,   D,   F,   G,   H,   J,   K,   L,   SCLN,QUOT,     ENT,  \
+        LSFT,Z,   X,   C,   V,   B,   N,   M,   COMM,DOT, SLSH,          RSFT, \
+        LCTL,LGUI,LALT,          FN0,                SPC, RALT,FN0,RGUI, RCTL),
+    /* Overlay 1: SpaceFN
+     * ,-----------------------------------------------------------.
+     * |`    | F1| F2| F3| F4| F5| F6| F7| F8| F9|F10|F11|F12|Del  |
+     * |-----------------------------------------------------------|
+     * |     |   |   |   |   |   |   |PgU|Hom|End|PgU|   |   |Ins  |
+     * |-----------------------------------------------------------|
+     * |      |   |   |   |   |   |Lef|Dow|Up |Rig|PgD|   |        |
+     * |-----------------------------------------------------------|
+     * |        |   |   |   |   |   |PgD|Mut|VoD|VoU|   |          |
+     * |-----------------------------------------------------------|
+     * |    |    |    |           |            |    |    |    |    |
+     * `-----------------------------------------------------------'
+     */
+    KEYMAP_Z62(
+        GRV, F1,  F2,  F3,  F4,  F5,  F6,  F7,  F8,  F9,  F10, F11, F12, DEL,  \
+        TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,PGUP,HOME,END, PGUP,TRNS,TRNS,INS,  \
+        TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,LEFT,DOWN,UP,  RGHT,PGDN,TRNS,     TRNS, \
+        TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,PGDN,MUTE,VOLD,VOLU,TRNS,          TRNS, \
+        TRNS,TRNS,TRNS,          TRNS,               SPC, TRNS,TRNS,TRNS,TRNS),
+};
+
+/*
+ * Fn action definition
+ */
+const action_t PROGMEM fn_actions[] = {
+    [0] = ACTION_LAYER_MOMENTARY(1), 
+    [1] = ACTION_MODS_KEY(MOD_LSFT, KC_GRV),    // tilde
+};


### PR DESCRIPTION
Z62 keyboard is cloned GH60 with split space bar. This patch solved independent configuration of both spaces. Provided keymap maps FN0 on left spacebar and add vi style cursor movement on second layer.  