### PR TITLE
Added support for Sun Non-US Backslash key

### DIFF
--- a/converter/sun_usb/keymap.c
+++ b/converter/sun_usb/keymap.c
@@ -63,7 +63,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     { KC_##K60, KC_##K61, KC_##K62, KC_##K63, KC_##K64, KC_##K65, KC_##K66, KC_##K67 }, \
     { KC_##K68, KC_##K69, KC_##K6A, KC_##K6B, KC_##K6C, KC_##K6D, KC_##K6E, KC_NO    }, \
     { KC_##K70, KC_##K71, KC_##K72, KC_##K73, KC_##K74, KC_##K75, KC_##K76, KC_##K77 }, \
-    { KC_##K78, KC_##K79, KC_##K7A, KC_##K7B, KC_NO,    KC_##K7D, KC_NO,    KC_NO    }  \
+    { KC_##K78, KC_##K79, KC_##K7A, KC_##K7B, KC_NUBS,  KC_##K7D, KC_NO,    KC_NO    }  \
 }
 
 /* CTCSP SHORT TYPE KEYBOARD */


### PR DESCRIPTION
I soldered and flashed a keyboard converter for Sun serial keyboards last night and it worked great except the ISO "<>|" key. After tinkering a little bit on the mapping to find out what keycode is generated, this change makes the key work on my German ISO keyboard. The keyboards defines are a bit convoluted and hard to follow, so I'm not 100% sure if this also should be added additionally in any of the other tables and defines in the file, ..?