### PR TITLE
Add IBM Twinax keyboard

### DIFF
--- a/keyboard/twinax/Makefile.pjrc
+++ b/keyboard/twinax/Makefile.pjrc
@@ -1,0 +1,108 @@
+#----------------------------------------------------------------------------
+# On command line:
+#
+# make all = Make software.
+#
+# make clean = Clean out built project files.
+#
+# make coff = Convert ELF to AVR COFF.
+#
+# make extcoff = Convert ELF to AVR Extended COFF.
+#
+# make program = Download the hex file to the device.
+#                Please customize your programmer settings(PROGRAM_CMD)
+#
+# make teensy = Download the hex file to the device, using teensy_loader_cli.
+#               (must have teensy_loader_cli installed).
+#
+# make dfu = Download the hex file to the device, using dfu-programmer (must
+#            have dfu-programmer installed).
+#
+# make flip = Download the hex file to the device, using Atmel FLIP (must
+#             have Atmel FLIP installed).
+#
+# make dfu-ee = Download the eeprom file to the device, using dfu-programmer
+#               (must have dfu-programmer installed).
+#
+# make flip-ee = Download the eeprom file to the device, using Atmel FLIP
+#                (must have Atmel FLIP installed).
+#
+# make debug = Start either simulavr or avarice as specified for debugging, 
+#              with avr-gdb or avr-insight as the front end for debugging.
+#
+# make filename.s = Just compile filename.c into the assembler code only.
+#
+# make filename.i = Create a preprocessed source file for use in submitting
+#                   bug reports to the GCC project.
+#
+# To rebuild project do "make clean" then "make all".
+#----------------------------------------------------------------------------
+
+# Target file name (without extension).
+TARGET = twinax_pjrc
+
+# Directory common source filess exist
+TMK_DIR = ../../tmk_core
+
+# Directory keyboard dependent files exist
+TARGET_DIR = .
+
+# keyboard dependent files
+SRC =	keymap.c \
+	matrix.c \
+	led.c
+
+CONFIG_H = config.h
+
+
+# MCU name, you MUST set this to match the board you are using
+# type "make clean" after changing this, so all files will be rebuilt
+#MCU = at90usb162       # Teensy 1.0
+#MCU = atmega32u4       # Teensy 2.0
+#MCU = at90usb646       # Teensy++ 1.0
+MCU = at90usb1286      # Teensy++ 2.0
+
+
+# Processor frequency.
+#   Normally the first thing your program should do is set the clock prescaler,
+#   so your program will run at the correct speed.  You should also set this
+#   variable to same clock speed.  The _delay_ms() macro uses this, and many
+#   examples use this variable to calculate timings.  Do not add a "UL" here.
+F_CPU = 16000000
+
+
+# Build Options
+#   comment out to disable the options.
+#
+BOOTMAGIC_ENABLE = yes	# Virtual DIP switch configuration(+1000)
+#MOUSEKEY_ENABLE = yes	# Mouse keys(+5000)
+EXTRAKEY_ENABLE = yes	# Audio control and System control(+600)
+CONSOLE_ENABLE = yes    # Console for debug
+COMMAND_ENABLE = yes    # Commands for debug and configuration
+#SLEEP_LED_ENABLE = yes  # Breathing sleep LED during USB suspend
+#NKRO_ENABLE = yes	# USB Nkey Rollover(+500)
+#PS2_MOUSE_ENABLE = yes	# PS/2 mouse(TrackPoint) support
+
+
+# Search Path
+VPATH += $(TARGET_DIR)
+VPATH += $(TMK_DIR)
+
+include $(TMK_DIR)/protocol/pjrc.mk
+include $(TMK_DIR)/common.mk
+include $(TMK_DIR)/rules.mk
+
+ansi: OPT_DEFS += -DLAYOUT_ANSI
+ansi: all
+
+ansi_150: OPT_DEFS += -DLAYOUT_ANSI_150
+ansi_150: all
+
+iso: OPT_DEFS += -DLAYOUT_ISO
+iso: all
+
+iso_150: OPT_DEFS += -DLAYOUT_ISO_150
+iso_150: all
+
+7bit: OPT_DEFS += -DLAYOUT_7BIT
+7bit: all

--- a/keyboard/twinax/config.h
+++ b/keyboard/twinax/config.h
@@ -1,0 +1,50 @@
+/*
+ * Configuration for IBM Twinax keyboard(1394312, german version)
+ * (C) Copyright 2019
+ * Dirk Eibach <dirk.eibach@gmail.com>
+ * 
+ * Based on Model M support by Les Orchard.
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef CONFIG_H
+#define CONFIG_H
+
+/* USB Device descriptor parameter */
+#define VENDOR_ID       0xFEED
+#define PRODUCT_ID      0x6057
+#define DEVICE_VER      0x0001
+#define MANUFACTURER    IBM
+#define PRODUCT         Twinax
+
+/* message strings */
+#define DESCRIPTION     t.m.k. keyboard firmware for IBM Twinax
+
+/* matrix size */
+#define MATRIX_ROWS 20
+#define MATRIX_COLS 8
+
+/* define if matrix has ghost */
+#define MATRIX_HAS_GHOST
+
+/* Set 0 if need no debouncing */
+#define DEBOUNCE    5
+
+/* key combination for command */
+#define IS_COMMAND() ( \
+    keyboard_report->mods == (MOD_BIT(KC_LALT) | MOD_BIT(KC_RALT)) \
+)
+
+#endif

--- a/keyboard/twinax/keymap.c
+++ b/keyboard/twinax/keymap.c
@@ -1,0 +1,86 @@
+/*
+ * Keymap for IBM Twinax keyboard(1394312, german version)
+ * (C) Copyright 2019
+ * Dirk Eibach <dirk.eibach@gmail.com>
+ *
+ * Based on Model M support by Les Orchard.
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "keycode.h"
+#include "action.h"
+#include "action_macro.h"
+#include "report.h"
+#include "host.h"
+#include "debug.h"
+#include "keymap.h"
+
+#define KEYMAP( \
+                  K0J,K1J,K1K,K2J,K3J,K3K,K4J,K5J,K5K,K6J,K7J,K7K,                                          \
+                  K0K,K0L,K1L,K2K,K2L,K3L,K4K,K4L,K5L,K6K,K6L,K7L,                                          \
+                                                                                                            \
+    K3B,K3C,  K3E, K2E,K2F,K2G,K2H,K3H,K3I,K2I,K2M,K2N,K2O,K3O,K3M,    K3P,  K3Q,K3R,K2Q,  K2P,K2R,K2S,K2A, \
+    K2B,K4B,  K4C, K4E,K4F,K4G,K4H,K5H,K5I,K4I,K4M,K4N,K4O,K5O,K5M,          K1Q,K5Q,K4Q,  K4P,K4R,K4S,K4A, \
+    K5B,K5C,  K6C, K1E,K1F,K1G,K1H,K0H,K0I,K1I,K1M,K1N,K1O,K0O,K6O,    K6P,      K0Q,      K1P,K1R,K1S,K1A, \
+    K1B,K1C,  K7D, K7E,K6E,K6F,K6G,K6H,K7H,K7I,K6I,K6M,K6N,K7O,        K6D,  K6A,K0T,K1T,  K6B,K6R,K6S,K7T, \
+    K0C,K0B,  K0A,    K7A,            K7B,                    K0D,     K7C,      K0P,          K7R,K7S      \
+) { \
+    { KC_##K0A, KC_##K1A, KC_##K2A, KC_NO,    KC_##K4A, KC_NO,    KC_##K6A, KC_##K7A }, \
+    { KC_##K0B, KC_##K1B, KC_##K2B, KC_##K3B, KC_##K4B, KC_##K5B, KC_##K6B, KC_##K7B }, \
+    { KC_##K0C, KC_##K1C, KC_NO,    KC_##K3C, KC_##K4C, KC_##K5C, KC_##K6C, KC_##K7C }, \
+    { KC_##K0D, KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_##K6D, KC_##K7D }, \
+    { KC_NO,    KC_##K1E, KC_##K2E, KC_##K3E, KC_##K4E, KC_NO,    KC_##K6E, KC_##K7E }, \
+    { KC_NO,    KC_##K1F, KC_##K2F, KC_NO,    KC_##K4F, KC_NO,    KC_##K6F, KC_NO    }, \
+    { KC_NO,    KC_##K1G, KC_##K2G, KC_NO,    KC_##K4G, KC_NO,    KC_##K6G, KC_NO    }, \
+    { KC_##K0H, KC_##K1H, KC_##K2H, KC_##K3H, KC_##K4H, KC_##K5H, KC_##K6H, KC_##K7H }, \
+    { KC_##K0I, KC_##K1I, KC_##K2I, KC_##K3I, KC_##K4I, KC_##K5I, KC_##K6I, KC_##K7I }, \
+    { KC_##K0J, KC_##K1J, KC_##K2J, KC_##K3J, KC_##K4J, KC_##K5J, KC_##K6J, KC_##K7J }, \
+    { KC_##K0K, KC_##K1K, KC_##K2K, KC_##K3K, KC_##K4K, KC_##K5K, KC_##K6K, KC_##K7K }, \
+    { KC_##K0L, KC_##K1L, KC_##K2L, KC_##K3L, KC_##K4L, KC_##K5L, KC_##K6L, KC_##K7L }, \
+    { KC_NO,    KC_##K1M, KC_##K2M, KC_##K3M, KC_##K4M, KC_##K5M, KC_##K6M, KC_NO    }, \
+    { KC_NO,    KC_##K1N, KC_##K2N, KC_NO,    KC_##K4N, KC_NO,    KC_##K6N, KC_NO    }, \
+    { KC_##K0O, KC_##K1O, KC_##K2O, KC_##K3O, KC_##K4O, KC_##K5O, KC_##K6O, KC_##K7O }, \
+    { KC_##K0P, KC_##K1P, KC_##K2P, KC_##K3P, KC_##K4P, KC_NO,    KC_##K6P, KC_NO    }, \
+    { KC_##K0Q, KC_##K1Q, KC_##K2Q, KC_##K3Q, KC_##K4Q, KC_##K5Q, KC_NO,    KC_NO    }, \
+    { KC_NO,    KC_##K1R, KC_##K2R, KC_##K3R, KC_##K4R, KC_NO,    KC_##K6R, KC_##K7R }, \
+    { KC_NO,    KC_##K1S, KC_##K2S, KC_NO,    KC_##K4S, KC_NO,    KC_##K6S, KC_##K7S }, \
+    { KC_##K0T, KC_##K1T, KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_NO,    KC_##K7T }, \
+}
+
+const uint8_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    KEYMAP(
+                         F13, F14, F15, F16, F17, F18, F19, F20, F21, F22, F23, F24,
+                         F1,  F2,  F3,  F4,  F5,  F6,  F7,  F8,  F9,  F10, F11, F12,
+
+        PSCR,ESC,   GRV, 1,   2,   3,   4,   5,   6,   7,   8,   9,   0,   MINS,EQL,      BSPC,  INS, HOME,PGUP,  NLCK,PSLS,PAST,PMNS,
+        SLCK,INT4,  TAB, Q,   W,   E,   R,   T,   Y,   U,   I,   O,   P,   LBRC,RBRC,            DEL, END, PGDN,  P7,  P8,  P9,  PPLS,
+        PAUS,INT5,  CAPS,A,   S,   D,   F,   G,   H,   J,   K,   L,   SCLN,QUOT,BSLS,     ENT,        UP,         P4,  P5,  P6,  PCMM,
+        APP, INT6,  LSFT,NUBS,Z,   X,   C,   V,   B,   N,   M,   COMM,DOT, SLSH,          RSFT,  LEFT,INT2,RGHT,  P1,  P2,  P3,  PENT,
+        RGUI,LGUI,  LCTL,     LALT,               SPC,                          RALT,     RCTL,       DOWN,            P0,  PDOT
+    ),
+};
+
+#define KEYCODE(layer, row, col) (pgm_read_byte(&keymaps[(layer)][(row)][(col)]))
+
+const action_t PROGMEM fn_actions[] = {};
+
+#define KEYMAPS_SIZE    (sizeof(keymaps) / sizeof(keymaps[0]))
+
+uint8_t keymap_get_keycode(uint8_t layer, uint8_t row, uint8_t col)
+{
+    return KEYCODE(layer, row, col);
+}

--- a/keyboard/twinax/led.c
+++ b/keyboard/twinax/led.c
@@ -1,0 +1,25 @@
+/*
+ * LED support for IBM Twinax keyboard(1394312, german version)
+ * (C) Copyright 2019
+ * Dirk Eibach <dirk.eibach@gmail.com>
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "led.h"
+
+void led_set(uint8_t usb_led)
+{
+/* this keyboard has no leds */
+}

--- a/keyboard/twinax/matrix.c
+++ b/keyboard/twinax/matrix.c
@@ -1,0 +1,202 @@
+/*
+ * Matrix for IBM Twinax keyboard(1394312, german version)
+ * (C) Copyright 2019
+ * Dirk Eibach <dirk.eibach@gmail.com>
+ * 
+ * Based on Model M support by Les Orchard.
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <stdint.h>
+#include <stdbool.h>
+#include <avr/io.h>
+#include <util/delay.h>
+#include "print.h"
+#include "debug.h"
+#include "util.h"
+#include "matrix.h"
+
+
+#ifndef DEBOUNCE
+#   define DEBOUNCE	10
+#endif
+static uint8_t debouncing = DEBOUNCE;
+
+// bit array of key state(1:on, 0:off)
+static matrix_row_t matrix[MATRIX_ROWS];
+static matrix_row_t matrix_debouncing[MATRIX_ROWS];
+
+static uint32_t read_rows(void);
+static void init_rows(void);
+static void unselect_cols(void);
+static void select_col(uint8_t col);
+
+uint8_t matrix_rows(void)
+{
+    return MATRIX_ROWS;
+}
+
+uint8_t matrix_cols(void)
+{
+    return MATRIX_COLS;
+}
+
+void matrix_init(void)
+{
+    unselect_cols();
+    init_rows();
+
+    // initialize matrix state: all keys off
+    for (uint8_t i = 0; i < MATRIX_ROWS; i++)  {
+        matrix[i] = 0;
+        matrix_debouncing[i] = 0;
+    }
+
+    debug_enable=true;
+}
+
+uint8_t matrix_scan(void)
+{
+    for (uint8_t col = 0; col < MATRIX_COLS; col++) {
+        select_col(col);
+        _delay_us(30);       // without this wait it won't read stable value.
+        uint32_t rows = read_rows();
+        for (uint8_t row = 0; row < MATRIX_ROWS; row++) {
+            bool prev_bit = matrix_debouncing[row] & ((matrix_row_t)1<<col);
+            bool curr_bit = rows & (1UL<<row);
+#if 0
+            if (curr_bit)
+                xprintf("%u%c\n", col, 'A' + row);
+#endif
+            if (prev_bit != curr_bit) {
+                matrix_debouncing[row] ^= ((matrix_row_t)1<<col);
+                if (debouncing) {
+                    dprint("bounce!: "); dprintf("%02X", debouncing); dprintln();
+                }
+                debouncing = DEBOUNCE;
+            }
+        }
+        unselect_cols();
+    }
+
+    if (debouncing) {
+        if (--debouncing) {
+            _delay_ms(1);
+        } else {
+            for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
+                matrix[i] = matrix_debouncing[i];
+            }
+        }
+    }
+
+    return 1;
+}
+
+bool matrix_is_modified(void)
+{
+    if (debouncing) return false;
+    return true;
+}
+
+bool matrix_is_on(uint8_t row, uint8_t col)
+{
+    return (matrix[row] & ((matrix_row_t)1<<col));
+}
+
+matrix_row_t matrix_get_row(uint8_t row)
+{
+    return matrix[row];
+}
+
+void matrix_print(void)
+{
+    print("\nr/c 01234567\n");
+    for (uint8_t row = 0; row < matrix_rows(); row++) {
+        xprintf(" %c: ", 'A'+row);
+        pbin_reverse(matrix_get_row(row));
+#ifdef MATRIX_HAS_GHOST
+        if (matrix_has_ghost_in_row(row)) {
+            print(" <ghost");
+        }
+#endif
+        print("\n");
+    }
+}
+
+uint8_t matrix_key_count(void)
+{
+    uint8_t count = 0;
+    for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
+        count += bitpop32(matrix[i]);
+    }
+    return count;
+}
+
+/* Row pin configuration
+ * row: 0  1  2  3  4  5  6  7  8  9  10 11 12 13 14 15 16 17 18 19
+ * pin: B7 D0 D1 D2 D3 D4 D5 E7 D7 E0 E1 C0 C1 C2 C3 C4 C5 C6 C7 B6
+ */
+static void init_rows(void)
+{
+    // Input with pull-up(DDR:0, PORT:1)
+    DDRB  &= ~0b10000000;
+    PORTB |=  0b10000000;
+    DDRC  &= ~0b11111111;
+    PORTC |=  0b11111111;
+    DDRD  &= ~0b10111111;
+    PORTD |=  0b10111111;
+    DDRE  &= ~0b11000011;
+    PORTE |=  0b11000011;
+}
+
+static uint32_t read_rows(void)
+{
+    return (PINB&(1<<7) ? 0 : (1UL<<0)) |
+           (PIND&(1<<0) ? 0 : (1UL<<1)) |
+           (PIND&(1<<1) ? 0 : (1UL<<2)) |
+           (PIND&(1<<2) ? 0 : (1UL<<3)) |
+           (PIND&(1<<3) ? 0 : (1UL<<4)) |
+           (PIND&(1<<4) ? 0 : (1UL<<5)) |
+           (PIND&(1<<5) ? 0 : (1UL<<6)) |
+           (PINE&(1<<7) ? 0 : (1UL<<7)) |
+           (PIND&(1<<7) ? 0 : (1UL<<8)) |
+           (PINE&(1<<0) ? 0 : (1UL<<9)) |
+           (PINE&(1<<1) ? 0 : (1UL<<10)) |
+           (PINC&(1<<0) ? 0 : (1UL<<11)) |
+           (PINC&(1<<1) ? 0 : (1UL<<12)) |
+           (PINC&(1<<2) ? 0 : (1UL<<13)) |
+           (PINC&(1<<3) ? 0 : (1UL<<14)) |
+           (PINC&(1<<4) ? 0 : (1UL<<15)) |
+           (PINC&(1<<5) ? 0 : (1UL<<16)) |
+           (PINC&(1<<6) ? 0 : (1UL<<17)) |
+           (PINC&(1<<7) ? 0 : (1UL<<18)) |
+           (PINE&(1<<6) ? 0 : (1UL<<19));
+}
+
+/* Column pin configuration
+ * col:  0  1  2  3  4  5  6  7
+ * pin: F0 F1 F2 F3 F4 F5 F6 F7
+ */
+static void unselect_cols(void)
+{
+    // Hi-Z(DDR:0, PORT:0) to unselect
+    DDRF  &= ~0b11111111;
+    PORTF |=  0b11111111;
+}
+
+static void select_col(uint8_t col)
+{
+    DDRF  |=  (1 << col);
+    PORTF &= ~(1 << col);
+}


### PR DESCRIPTION
Add support for IBM Twinax keyboard(1394312, german version), using
Teensy++ 2.0 hardware.

Based on Model M support by Les Orchard.
(https://blog.lmorchard.com/2016/02/21/modelm-controller/)

Signed-off-by: Dirk Eibach <dirk.eibach@gmail.com>