### PR TITLE
Debouncing for GH60 keyboard Fix

### DIFF
--- a/keyboard/gh60/matrix.c
+++ b/keyboard/gh60/matrix.c
@@ -73,12 +73,11 @@ uint8_t matrix_scan(void)
     }
 
     if (debouncing) {
-        if (--debouncing) {
-            _delay_ms(1);
-        } else {
-            for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
-                matrix[i] = matrix_debouncing[i];
-            }
+        _delay_ms(1);
+        debouncing--;
+    } else {
+        for (uint8_t i = 0; i < MATRIX_ROWS; i++) {
+            matrix[i] = matrix_debouncing[i];
         }
     }
 


### PR DESCRIPTION
The `config.h` of the keyboard says that you can disable debouncing when you set this to zero:
>/* Set 0 if debouncing isn't needed */
>#define DEBOUNCE    5

However it doesn't work when you do it, because then the matrix  in `matrix.c` doesn't get updated.
Also the debouncing delay doesn't correspond to the value of `DEBOUNCE` in milliseconds (-1ms).
This pull request should fix those problems.