### PR TITLE
Adding support for the IBM 102 Terminal Keyboard ( #1386304 )

### DIFF
--- a/converter/terminal_usb/keymap.c
+++ b/converter/terminal_usb/keymap.c
@@ -100,6 +100,37 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     { KC_NO,    KC_NO,    KC_NO,    KC_NO   , KC_##K84, KC_NO,    KC_NO,    KC_NO,   }, \
 }
 
+/*
+ * IBM Terminal keyboard 1386304, 102-key
+ */
+#define KEYMAP_102( \
+    K08,    K07,K0F,K17,K1F,K27,K2F,K37,K3F,K47,K4F,K56,K5E,  K57,K5F,K62,                   \
+                                                                                             \
+    K0E,K16,K1E,K26,K25,K2E,K36,K3D,K3E,K46,K45,K4E,K55,K66,  K67,K6E,K6F,  K76,K77,K7E,K84, \
+    K0D,K15,K1D,K24,K2D,K2C,K35,K3C,K43,K44,K4D,K54,K5B,K5C,  K64,K65,K6D,  K6C,K75,K7D,K7C, \
+    K14,K1C,K1B,K23,K2B,K34,K33,K3B,K42,K4B,K4C,K52,    K5A,                K6B,K73,K74,K7B, \
+    K12,    K1A,K22,K21,K2A,K32,K31,K3A,K41,K49,K4A,    K59,      K63,      K69,K72,K7A,     \
+    K11,    K19,            K29,                K39,    K58,  K61,K60,K6A,  K70,    K71,K79  \
+) { \
+    { KC_NO,    KC_NO   , KC_NO,    KC_NO   , KC_NO   , KC_NO   , KC_NO   , KC_##K07 }, \
+    { KC_##K08, KC_NO   , KC_NO   , KC_NO   , KC_NO   , KC_##K0D, KC_##K0E, KC_##K0F }, \
+    { KC_NO   , KC_##K11, KC_##K12, KC_NO   , KC_##K14, KC_##K15, KC_##K16, KC_##K17 }, \
+    { KC_NO   , KC_##K19, KC_##K1A, KC_##K1B, KC_##K1C, KC_##K1D, KC_##K1E, KC_##K1F }, \
+    { KC_NO   , KC_##K21, KC_##K22, KC_##K23, KC_##K24, KC_##K25, KC_##K26, KC_##K27 }, \
+    { KC_NO   , KC_##K29, KC_##K2A, KC_##K2B, KC_##K2C, KC_##K2D, KC_##K2E, KC_##K2F }, \
+    { KC_NO   , KC_##K31, KC_##K32, KC_##K33, KC_##K34, KC_##K35, KC_##K36, KC_##K37 }, \
+    { KC_NO   , KC_##K39, KC_##K3A, KC_##K3B, KC_##K3C, KC_##K3D, KC_##K3E, KC_##K3F }, \
+    { KC_NO   , KC_##K41, KC_##K42, KC_##K43, KC_##K44, KC_##K45, KC_##K46, KC_##K47 }, \
+    { KC_NO   , KC_##K49, KC_##K4A, KC_##K4B, KC_##K4C, KC_##K4D, KC_##K4E, KC_##K4F }, \
+    { KC_NO   , KC_NO   , KC_##K52, KC_NO   , KC_##K54, KC_##K55, KC_##K56, KC_##K57 }, \
+    { KC_##K58, KC_##K59, KC_##K5A, KC_##K5B, KC_##K5C, KC_NO   , KC_##K5E, KC_##K5F }, \
+    { KC_##K60, KC_##K61, KC_##K62, KC_##K63, KC_##K64, KC_##K65, KC_##K66, KC_##K67 }, \
+    { KC_NO   , KC_##K69, KC_##K6A, KC_##K6B, KC_##K6C, KC_##K6D, KC_##K6E, KC_##K6F }, \
+    { KC_##K70, KC_##K71, KC_##K72, KC_##K73, KC_##K74, KC_##K75, KC_##K76, KC_##K77 }, \
+    { KC_NO   , KC_##K79, KC_##K7A, KC_##K7B, KC_##K7C, KC_##K7D, KC_##K7E, KC_NO    }, \
+    { KC_NO,    KC_NO,    KC_NO,    KC_NO   , KC_##K84, KC_NO,    KC_NO,    KC_NO,   }, \
+}
+
 // Assign Fn key(0-7) to a layer to which switch with the Fn key pressed.
 const uint8_t PROGMEM fn_layer[] = {
     0,              // Fn0
@@ -198,6 +229,35 @@ const uint8_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     CAPS,   A,   S,   D,   F,   G,   H,   J,   K,   L,SCLN,QUOT,      ENT,                           P4,  P5,  P6,PPLS,
     LSFT,        Z,   X,   C,   V,   B,   N,   M,COMM, DOT,SLSH,     RSFT,            UP,            P1,  P2,  P3,
     LCTL,     LALT,                SPC,                    RALT,     RCTL,     LEFT,DOWN,RGHT,       P0,     PDOT,PENT
+    ),
+*/
+  
+/* 102-key keymaps */
+    /* 0: default
+     * ,---.   ,---------------. ,---------------. ,---------------. ,-----------.
+     * |Esc|   |F1 |F2 |F3 |F4 | |F5 |F6 |F7 |F8 | |F9 |F10|F11|F12| |PrS|ScL|Pau|
+     * `---'   `---------------' `---------------' `---------------' `-----------'
+     * ,-----------------------------------------------------------. ,-----------. ,---------------.
+     * |  `|  1|  2|  3|  4|  5|  6|  7|  8|  9|  0|  -|  =|Backspa| |Ins|Hom|PgU| |NmL|  /|  *|SEL|
+     * |-----------------------------------------------------------| |-----------| |---------------|
+     * |Tab  |  Q|  W|  E|  R|  T|  Y|  U|  I|  O|  P|  [|  ]|    \| |Del|End|PgD| |  7|  8|  9| - |
+     * |-----------------------------------------------------------| `-----------' |-----------|---|
+     * |CapsLo|  A|  S|  D|  F|  G|  H|  J|  K|  L|  ;|  '|Return  |               |  4|  5|  6| , |
+     * |-----------------------------------------------------------|     ,---.     |---------------|
+     * |Shift   |  Z|  X|  C|  V|  B|  N|  M|  ,|  ,|  /|Shift     |     |Up |     |  1|  2|  3|   |
+     * |-----------------------------------------------------------| ,-----------. |-----------|Ent|
+     * |Ctrl|    |Alt |          Space              |Alt |    |Ctrl| |Lef|Dow|Rig| |      0|  .|   |
+     * `----'    `---------------------------------------'    `----' `-----------' `---------------'
+     */
+/*
+    KEYMAP_102(
+    ESC,       F1,  F2,  F3,  F4,  F5,  F6,  F7,  F8,  F9, F10, F11, F12,       PSCR,SLCK, BRK,
+
+    GRV,   1,   2,   3,   4,   5,   6,   7,   8,   9,   0,  MINS, EQL,BSPC,     INS,HOME,PGUP,       NLCK,PSLS,PAST,ESC,
+    TAB,   Q,   W,   E,   R,   T,   Y,   U,   I,   O,   P,  LBRC,RBRC,BSLS,     DEL, END,PGDN,       P7,  P8,  P9,  PMNS,
+    CAPS,  A,   S,   D,   F,   G,   H,   J,   K,   L,SCLN,QUOT,        ENT,                          P4,  P5,  P6,  PCMM,
+    LSFT,       Z,   X,   C,   V,   B,   N,   M,COMM, DOT,SLSH,       RSFT,            UP,           P1,  P2,  P3,
+    LCTL,     LALT,                SPC,                   RALT,       RCTL,     LEFT,DOWN,RGHT,      P0,     PDOT,  PENT
     ),
 */
 };


### PR DESCRIPTION
Adding support for the IBM 102 Terminal Keyboard ( #1386304 )
The 1386304 has a slightly different matrix than the 122/101 terminal keyboard.