### PR TITLE
Add block_mods to make Shift+(Shift_KEY) = KEY

### DIFF
--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -81,12 +81,17 @@ void process_action(keyrecord_t *record)
                 uint8_t mods = (action.kind.id == ACT_LMODS) ?  action.key.mods :
                                                                 action.key.mods<<4;
                 if (event.pressed) {
+                     if ((get_mods() & MODS_SHIFT_MASK) && (mods & MODS_SHIFT_MASK)) {
+                        block_mods |= MODS_SHIFT_MASK;
+                        mods &= ~MODS_SHIFT_MASK;
+                    }
                     if (mods) {
                         add_weak_mods(mods);
                         send_keyboard_report();
                     }
                     register_code(action.key.code);
                 } else {
+                    block_mods &= ~MODS_SHIFT_MASK;
                     unregister_code(action.key.code);
                     if (mods) {
                         del_weak_mods(mods);

--- a/tmk_core/common/action_util.c
+++ b/tmk_core/common/action_util.c
@@ -30,6 +30,8 @@ static inline void del_key_bit(uint8_t code);
 static uint8_t real_mods = 0;
 static uint8_t weak_mods = 0;
 
+uint8_t block_mods = 0;
+
 #ifdef USB_6KRO_ENABLE
 #define RO_ADD(a, b) ((a + b) % KEYBOARD_REPORT_KEYS)
 #define RO_SUB(a, b) ((a - b + KEYBOARD_REPORT_KEYS) % KEYBOARD_REPORT_KEYS)
@@ -55,6 +57,7 @@ static int16_t oneshot_time = 0;
 void send_keyboard_report(void) {
     keyboard_report->mods  = real_mods;
     keyboard_report->mods |= weak_mods;
+    keyboard_report->mods &= ~block_mods;
 #ifndef NO_ACTION_ONESHOT
     if (oneshot_mods) {
 #if (defined(ONESHOT_TIMEOUT) && (ONESHOT_TIMEOUT > 0))

--- a/tmk_core/common/action_util.h
+++ b/tmk_core/common/action_util.h
@@ -25,6 +25,9 @@ extern "C" {
 #endif
 
 extern report_keyboard_t *keyboard_report;
+extern uint8_t block_mods;
+#define MODS_SHIFT_MASK (MOD_BIT(KC_LSHIFT) | MOD_BIT(KC_RSHIFT))
+#define MODS_GUI_MASK   (MOD_BIT(KC_LGUI) | MOD_BIT(KC_RGUI))
 
 void send_keyboard_report(void);
 


### PR DESCRIPTION
For example, If a key is set to be "{ ", then this key with shift will output "[".
And by using Shift with layer on, people can creat their own shift layer like "* [".  Pressing a single key is "*"(in fact it is shift_8), while with Shift it would be "[" (in fact it is Shift_Layer7 and Shift_[).
block_mods can also used to disable win key without modifying bootmaigc value.