### PR TITLE
Extended Mouse Descriptor

### DIFF
--- a/tmk_core/common/host.c
+++ b/tmk_core/common/host.c
@@ -65,6 +65,11 @@ void host_keyboard_send(report_keyboard_t *report)
 void host_mouse_send(report_mouse_t *report)
 {
     if (!driver) return;
+#ifdef ENABLE_16_BIT_MOUSE_REPORT
+    // clip and copy to Boot protocol XY
+    report->boot_x = (report->x > 127) ? 127 : ((report->x < -127) ? -127 : report->x);
+    report->boot_y = (report->y > 127) ? 127 : ((report->y < -127) ? -127 : report->y);
+#endif
     (*driver->send_mouse)(report);
 }
 

--- a/tmk_core/common/report.h
+++ b/tmk_core/common/report.h
@@ -160,6 +160,8 @@ typedef struct {
 #ifdef ENABLE_16_BIT_MOUSE_REPORT
 typedef struct {
     uint8_t buttons;
+    int8_t boot_x;
+    int8_t boot_y;
     int16_t x;
     int16_t y;
     int16_t v;

--- a/tmk_core/common/report.h
+++ b/tmk_core/common/report.h
@@ -157,6 +157,15 @@ typedef struct {
 } __attribute__ ((packed)) report_keyboard_t;
 */
 
+#ifdef ENABLE_16_BIT_MOUSE_REPORT
+typedef struct {
+    uint8_t buttons;
+    int16_t x;
+    int16_t y;
+    int16_t v;
+    int16_t h;
+} __attribute__ ((packed)) report_mouse_t;
+#else
 typedef struct {
     uint8_t buttons;
     int8_t x;
@@ -164,6 +173,7 @@ typedef struct {
     int8_t v;
     int8_t h;
 } __attribute__ ((packed)) report_mouse_t;
+#endif
 
 
 /* keycode to system usage */

--- a/tmk_core/protocol/lufa/descriptor.c
+++ b/tmk_core/protocol/lufa/descriptor.c
@@ -123,15 +123,46 @@ const USB_Descriptor_HIDReport_Datatype_t PROGMEM MouseReport[] =
 
             HID_RI_USAGE_PAGE(8, 0x09), /* Button */
             HID_RI_USAGE_MINIMUM(8, 0x01),  /* Button 1 */
-            HID_RI_USAGE_MAXIMUM(8, 0x05),  /* Button 5 */
+            HID_RI_USAGE_MAXIMUM(8, 0x08),  /* Button 8 */
             HID_RI_LOGICAL_MINIMUM(8, 0x00),
             HID_RI_LOGICAL_MAXIMUM(8, 0x01),
-            HID_RI_REPORT_COUNT(8, 0x05),
+            HID_RI_REPORT_COUNT(8, 0x08),
             HID_RI_REPORT_SIZE(8, 0x01),
             HID_RI_INPUT(8, HID_IOF_DATA | HID_IOF_VARIABLE | HID_IOF_ABSOLUTE),
+
+#ifndef ENABLE_16_BIT_MOUSE_REPORT
+            HID_RI_USAGE_PAGE(8, 0x01), /* Generic Desktop */
+            HID_RI_USAGE(8, 0x30), /* Usage X */
+            HID_RI_USAGE(8, 0x31), /* Usage Y */
+            HID_RI_LOGICAL_MINIMUM(8, -127),
+            HID_RI_LOGICAL_MAXIMUM(8, 127),
+            HID_RI_REPORT_COUNT(8, 0x02),
+            HID_RI_REPORT_SIZE(8, 0x08),
+            HID_RI_INPUT(8, HID_IOF_DATA | HID_IOF_VARIABLE | HID_IOF_RELATIVE),
+
+            HID_RI_USAGE(8, 0x38), /* Wheel */
+            HID_RI_LOGICAL_MINIMUM(8, -127),
+            HID_RI_LOGICAL_MAXIMUM(8, 127),
             HID_RI_REPORT_COUNT(8, 0x01),
-            HID_RI_REPORT_SIZE(8, 0x03),
-            HID_RI_INPUT(8, HID_IOF_CONSTANT),
+            HID_RI_REPORT_SIZE(8, 0x08),
+            HID_RI_INPUT(8, HID_IOF_DATA | HID_IOF_VARIABLE | HID_IOF_RELATIVE),
+
+            HID_RI_USAGE_PAGE(8, 0x0C), /* Consumer */
+            HID_RI_USAGE(16, 0x0238), /* AC Pan (Horizontal wheel) */
+            HID_RI_LOGICAL_MINIMUM(8, -127),
+            HID_RI_LOGICAL_MAXIMUM(8, 127),
+            HID_RI_REPORT_COUNT(8, 0x01),
+            HID_RI_REPORT_SIZE(8, 0x08),
+            HID_RI_INPUT(8, HID_IOF_DATA | HID_IOF_VARIABLE | HID_IOF_RELATIVE),
+#else
+            /* Boot protocol XY ignored in Report protocol */
+            HID_RI_USAGE_PAGE(8, 0xff), /* Vendor */
+            HID_RI_USAGE(8, 0xff), /* Vendor  */
+            HID_RI_LOGICAL_MINIMUM(8, -127),
+            HID_RI_LOGICAL_MAXIMUM(8, 127),
+            HID_RI_REPORT_COUNT(8, 0x02),
+            HID_RI_REPORT_SIZE(8, 0x08),
+            HID_RI_INPUT(8, HID_IOF_DATA | HID_IOF_VARIABLE | HID_IOF_RELATIVE),
 
             HID_RI_USAGE_PAGE(8, 0x01), /* Generic Desktop */
             HID_RI_USAGE(8, 0x30), /* Usage X */
@@ -156,6 +187,7 @@ const USB_Descriptor_HIDReport_Datatype_t PROGMEM MouseReport[] =
             HID_RI_REPORT_COUNT(8, 0x01),
             HID_MOUSE_REPORT_SIZE,
             HID_RI_INPUT(8, HID_IOF_DATA | HID_IOF_VARIABLE | HID_IOF_RELATIVE),
+#endif
 
         HID_RI_END_COLLECTION(0),
     HID_RI_END_COLLECTION(0),

--- a/tmk_core/protocol/lufa/descriptor.c
+++ b/tmk_core/protocol/lufa/descriptor.c
@@ -84,6 +84,35 @@ const USB_Descriptor_HIDReport_Datatype_t PROGMEM KeyboardReport[] =
 };
 
 #ifdef MOUSE_ENABLE
+
+#ifdef ENABLE_16_BIT_MOUSE_REPORT
+    #define REPORT_SIZE 16
+
+    #ifndef MOUSE_PRECISION
+        #define MOUSE_PRECISION 16
+    #endif
+
+    #ifndef MOUSE_WHEEL_PRECISION
+        #define MOUSE_WHEEL_PRECISION 16
+    #endif
+#else
+    #define REPORT_SIZE 8
+
+    #ifndef MOUSE_PRECISION
+        #define MOUSE_PRECISION 8
+    #endif
+
+    #ifndef MOUSE_WHEEL_PRECISION
+        #define MOUSE_WHEEL_PRECISION 8
+    #endif
+#endif
+
+#define HID_MOUSE_REPORT_SIZE HID_RI_REPORT_SIZE(8, REPORT_SIZE)
+#define HID_MOUSE_LOGICAL_MINIMUM HID_RI_LOGICAL_MINIMUM(REPORT_SIZE, (-1 << (MOUSE_PRECISION - 1)) + 1)
+#define HID_MOUSE_LOGICAL_MAXIMUM HID_RI_LOGICAL_MAXIMUM(REPORT_SIZE, (1 << (MOUSE_PRECISION - 1)) - 1)
+#define HID_MOUSE_WHEEL_LOGICAL_MINIMUM HID_RI_LOGICAL_MINIMUM(REPORT_SIZE, (-1 << (MOUSE_WHEEL_PRECISION - 1)) + 1)
+#define HID_MOUSE_WHEEL_LOGICAL_MAXIMUM HID_RI_LOGICAL_MAXIMUM(REPORT_SIZE, (1 << (MOUSE_WHEEL_PRECISION - 1)) - 1)
+
 const USB_Descriptor_HIDReport_Datatype_t PROGMEM MouseReport[] =
 {
     HID_RI_USAGE_PAGE(8, 0x01), /* Generic Desktop */
@@ -107,25 +136,25 @@ const USB_Descriptor_HIDReport_Datatype_t PROGMEM MouseReport[] =
             HID_RI_USAGE_PAGE(8, 0x01), /* Generic Desktop */
             HID_RI_USAGE(8, 0x30), /* Usage X */
             HID_RI_USAGE(8, 0x31), /* Usage Y */
-            HID_RI_LOGICAL_MINIMUM(8, -127),
-            HID_RI_LOGICAL_MAXIMUM(8, 127),
+            HID_MOUSE_LOGICAL_MINIMUM,
+            HID_MOUSE_LOGICAL_MAXIMUM,
             HID_RI_REPORT_COUNT(8, 0x02),
-            HID_RI_REPORT_SIZE(8, 0x08),
+            HID_MOUSE_REPORT_SIZE,
             HID_RI_INPUT(8, HID_IOF_DATA | HID_IOF_VARIABLE | HID_IOF_RELATIVE),
 
             HID_RI_USAGE(8, 0x38), /* Wheel */
-            HID_RI_LOGICAL_MINIMUM(8, -127),
-            HID_RI_LOGICAL_MAXIMUM(8, 127),
+            HID_MOUSE_WHEEL_LOGICAL_MINIMUM,
+            HID_MOUSE_WHEEL_LOGICAL_MAXIMUM,
             HID_RI_REPORT_COUNT(8, 0x01),
-            HID_RI_REPORT_SIZE(8, 0x08),
+            HID_MOUSE_REPORT_SIZE,
             HID_RI_INPUT(8, HID_IOF_DATA | HID_IOF_VARIABLE | HID_IOF_RELATIVE),
 
             HID_RI_USAGE_PAGE(8, 0x0C), /* Consumer */
             HID_RI_USAGE(16, 0x0238), /* AC Pan (Horizontal wheel) */
-            HID_RI_LOGICAL_MINIMUM(8, -127),
-            HID_RI_LOGICAL_MAXIMUM(8, 127),
+            HID_MOUSE_WHEEL_LOGICAL_MINIMUM,
+            HID_MOUSE_WHEEL_LOGICAL_MAXIMUM,
             HID_RI_REPORT_COUNT(8, 0x01),
-            HID_RI_REPORT_SIZE(8, 0x08),
+            HID_MOUSE_REPORT_SIZE,
             HID_RI_INPUT(8, HID_IOF_DATA | HID_IOF_VARIABLE | HID_IOF_RELATIVE),
 
         HID_RI_END_COLLECTION(0),


### PR DESCRIPTION
This add Extended Mouse Descriptor, which uses 16-bit data for X and Y axis of mouse report, instead of 8-bit.

This change based on: https://github.com/tmk/tmk_keyboard/pull/692


TODO:
- [x] 16-bit width may be too much for vertical and horizontal scroll data -> scroll wheels still use 8bit
- [ ] check descriptor of consumer mouse products in the market
- [ ] see how extended report is interpreted on OS
- [x] PS/2 mouse data
- [ ] ADB mouse data