### PR TITLE
Unicomp New Model M broken Pause/Break key fix

### DIFF
--- a/converter/ibmpc_usb/ibmpc_usb.cpp
+++ b/converter/ibmpc_usb/ibmpc_usb.cpp
@@ -914,6 +914,7 @@ uint8_t IBMPCConverter::cs2_e0code(uint8_t code) {
         case 0x72: return 0x3F; // cursor down
         case 0x74: return 0x47; // cursor right
         case 0x75: return 0x4F; // cursor up
+        case 0x77: return 0x00; // Unicomp New Model M Pause/Break key fix
         case 0x7A: return 0x56; // page down
         case 0x7D: return 0x5E; // page up
         case 0x7C: return 0x7F; // Print Screen


### PR DESCRIPTION
The PS/2 controller code for Unicomp's current generation PS/2 keyboard sends the wrong scancodes when Ctrl + Pause (which should be Break) is pressed:

https://deskthority.net/viewtopic.php?f=2&t=25718
https://www.reddit.com/r/modelm/comments/n0u81o/anybody_out_there_rocking_a_ps2_unicomp_noticed/

Instead of it sending the Break sequence...

    E0 7E E0 F0 7E

... representing a press of Scroll Lock, which is Break because Ctrl is being pressed, it instead sends...

    E0 77

... representing a press of Num Lock, which is just the old way of getting Pause.

Since the E0 77 coming from the controller is not a normal sequence, this workaround does not interfere with Ctrl + Num Lock, which still Pauses as it should. It uses the same solution as the existing override to produce Break (for keyboards with more sensible controllers in them).