### PR TITLE
Feature: ibmpc_usb converter lock state indicators

### DIFF
--- a/converter/ibmpc_usb/Makefile
+++ b/converter/ibmpc_usb/Makefile
@@ -71,7 +71,7 @@ OPT_DEFS += -DSUSPEND_MODE_STANDBY
 #   comment out to disable the options.
 #
 BOOTMAGIC_ENABLE ?= no	# Virtual DIP switch configuration(+1150)
-MOUSEKEY_ENABLE ?= yes	# Mouse keys(+2200)
+MOUSEKEY_ENABLE ?= no	# Mouse keys(+2200)
 EXTRAKEY_ENABLE ?= yes	# Audio control and System control(+400)
 CONSOLE_ENABLE ?= yes	# Console for debug(+4150)
 COMMAND_ENABLE ?= yes	# Commands for debug and configuration(+3600)

--- a/converter/ibmpc_usb/ibmpc_usb.cpp
+++ b/converter/ibmpc_usb/ibmpc_usb.cpp
@@ -914,6 +914,7 @@ uint8_t IBMPCConverter::cs2_e0code(uint8_t code) {
         case 0x72: return 0x3F; // cursor down
         case 0x74: return 0x47; // cursor right
         case 0x75: return 0x4F; // cursor up
+        case 0x77: return 0x00; // Unicomp New Model M Pause/Break key fix
         case 0x7A: return 0x56; // page down
         case 0x7D: return 0x5E; // page up
         case 0x7C: return 0x7F; // Print Screen

--- a/converter/ibmpc_usb/ibmpc_usb.cpp
+++ b/converter/ibmpc_usb/ibmpc_usb.cpp
@@ -96,28 +96,49 @@ uint8_t ibmpc_mouse_buttons(void)
 
 void IBMPCConverter::set_led(uint8_t usb_led)
 {
-    // Sending before keyboard recognition may be harmful for XT keyboard
-    if (keyboard_kind == NONE) return;
-
-    // XT keyobard doesn't support any command and it is harmful perhaps
-    // https://github.com/tmk/tmk_keyboard/issues/635#issuecomment-626993437
-    if (keyboard_kind == PC_XT) return;
-    if (keyboard_kind == PC_MOUSE) return;
-
-    // It should be safe to send the command to keyboards with AT protocol
-    // - IBM Terminal doesn't support the command and response with 0xFE but it is not harmful.
-    // - Some other Terminals like G80-2551 supports the command.
-    //   https://geekhack.org/index.php?topic=103648.msg2894921#msg2894921
-
+    /* Pointing devices and original IBM PC ("XT") protocol keyboards do not
+     * support receiving data signals, only sending them, so it's probably not a
+     * good idea to send any to them:
+     * https://github.com/tmk/tmk_keyboard/issues/635#issuecomment-626993437
+     * 
+     * IBM terminal boards don't have LEDs, but are capable of receiving and
+     * responding to incoming data. This is useful, because it means we can send
+     * the enquiry byte to terminal keyboards, which will facilitate updating
+     * the lock state LEDs on terminal keyboards that do have them, like the
+     * Cherry G80-2551:
+     * https://geekhack.org/index.php?topic=103648.msg2894921#msg2894921
+     *
+     * The USB HID and IBM PC/AT protocols both set keyboards' lock state LEDs
+     * by sending a single byte in which each lock state is represented by one
+     * bit, but the bit order differs between protocols (see led.h and ibmpc.h).
+     */
+    switch (keyboard_kind) {
+        /* if the connected device is unidentified (temporarily or otherwise), a
+         * pointing device, or an "XT" protocol keyboard, do nothing: */
+        case NONE:
+        case PC_MOUSE:
+        case PC_XT:
+            break;
+        /* if keyboard returns "ACK" acknowledgement byte (0xFA) when LED update
+         * enquiry byte (0xED) is sent, reorganise USB HID LED byte into IBM bit
+         * order and send to keyboard to update all 3 of its lock state LEDs: */
+        default:
+            if (ibmpc.host_enq_led()) {
+                uint8_t ibm_led = 0;
+                if (usb_led & (1 << USB_LED_SCROLL_LOCK)) {
+                    ibm_led |= (1 << IBMPC_LED_SCROLL_LOCK);
+                }
+                if (usb_led & (1 << USB_LED_NUM_LOCK)) {
+                    ibm_led |= (1 << IBMPC_LED_NUM_LOCK);
+                }
+                if (usb_led & (1 << USB_LED_CAPS_LOCK)) {
+                    ibm_led |= (1 << IBMPC_LED_CAPS_LOCK);
+                }
+                ibmpc.host_set_led(ibm_led);
+            }
+            break;
     // TODO: PC_TERMINAL_IBM_RT support
-    uint8_t ibmpc_led = 0;
-    if (usb_led &  (1<<USB_LED_SCROLL_LOCK))
-        ibmpc_led |= (1<<IBMPC_LED_SCROLL_LOCK);
-    if (usb_led &  (1<<USB_LED_NUM_LOCK))
-        ibmpc_led |= (1<<IBMPC_LED_NUM_LOCK);
-    if (usb_led &  (1<<USB_LED_CAPS_LOCK))
-        ibmpc_led |= (1<<IBMPC_LED_CAPS_LOCK);
-    ibmpc.host_set_led(ibmpc_led);
+    }
 }
 
 int16_t IBMPCConverter::read_wait(uint16_t wait_ms)

--- a/converter/ibmpc_usb/ibmpc_usb.cpp
+++ b/converter/ibmpc_usb/ibmpc_usb.cpp
@@ -113,17 +113,17 @@ void IBMPCConverter::set_led(uint8_t usb_led)
      * bit, but the bit order differs between protocols (see led.h and ibmpc.h).
      */
     switch (keyboard_kind) {
-        /* if the connected device is unidentified (temporarily or otherwise), a
-         * pointing device, or an "XT" protocol keyboard, do nothing: */
+        /* If the connected device is unidentified (temporarily or otherwise), a
+         * pointing device, or an "XT" protocol keyboard, do nothing */
         case NONE:
-        case PC_MOUSE:
         case PC_XT:
+        case PC_MOUSE:
             break;
-        /* if keyboard returns "ACK" acknowledgement byte (0xFA) when LED update
+        /* If keyboard returns "ACK" acknowledgement byte (0xFA) when LED update
          * enquiry byte (0xED) is sent, reorganise USB HID LED byte into IBM bit
-         * order and send to keyboard to update all 3 of its lock state LEDs: */
+         * order and send to keyboard to update all 3 of its lock state LEDs */
         default:
-            if (ibmpc.host_enq_led()) {
+            if (ibmpc.host_led_enq()) {
                 uint8_t ibm_led = 0;
                 if (usb_led & (1 << USB_LED_SCROLL_LOCK)) {
                     ibm_led |= (1 << IBMPC_LED_SCROLL_LOCK);

--- a/converter/ibmpc_usb/ibmpc_usb.hpp
+++ b/converter/ibmpc_usb/ibmpc_usb.hpp
@@ -52,6 +52,8 @@ class IBMPCConverter {
 
     uint8_t process_interface(void);
 
+    void write_led_pin(uint8_t usb_led, uint8_t pin);
+
     void set_led(uint8_t usb_led);
 
     static inline void matrix_clear(void) {

--- a/converter/ibmpc_usb/led_pins.h
+++ b/converter/ibmpc_usb/led_pins.h
@@ -1,0 +1,33 @@
+/*
+Copyright 2023 an_achronism <87213873+an-achronism@users.noreply.github.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+/*
+The default pin assignments in this file have been chosen to retain full
+backwards compatibility with Soarer's old converter solution:
+https://geekhack.org/index.php?topic=17458.0
+*/
+
+// The Data Direction Register and port must match (default is F)
+#define LOCK_INDICATOR_DDR   DDRF
+#define LOCK_INDICATOR_PORT  PORTF
+
+// These pin numbers correspond with the chosen port, e.g. port F pin 5 is PF5
+#define CAPS_LOCK_PIN        5
+#define NUM_LOCK_PIN         6
+#define SCROLL_LOCK_PIN      7

--- a/tmk_core/protocol/ibmpc.cpp
+++ b/tmk_core/protocol/ibmpc.cpp
@@ -401,14 +401,17 @@ NEXT:
     return;
 }
 
-/* send LED state to keyboard */
-void IBMPC::host_set_led(uint8_t led)
+/* send enquiry byte to keyboard to check if it can handle LED state byte */
+bool IBMPC::host_enq_led(void)
 {
-    if (0xFA == host_send(0xED)) {
-        host_send(led);
-    }
+    return (host_send(IBMPC_SET_LED) == IBMPC_ACK);
 }
 
+/* send LED state byte to keyboard */
+void IBMPC::host_set_led(uint8_t led)
+{
+    host_send(led);
+}
 
 // NOTE: With this ISR data line should be read within 5us after clock falling edge.
 // Confirmed that ATmega32u4 can read data line in 2.5us from interrupt after

--- a/tmk_core/protocol/ibmpc.cpp
+++ b/tmk_core/protocol/ibmpc.cpp
@@ -401,13 +401,13 @@ NEXT:
     return;
 }
 
-/* send enquiry byte to keyboard to check if it can handle LED state byte */
+/* Send enquiry byte to keyboard to check if it can handle LED state byte */
 bool IBMPC::host_led_enq(void)
 {
     return (host_send(IBMPC_SET_LED) == IBMPC_ACK);
 }
 
-/* send LED state byte to keyboard */
+/* Send LED state byte to keyboard */
 void IBMPC::host_set_led(uint8_t led)
 {
     host_send(led);

--- a/tmk_core/protocol/ibmpc.cpp
+++ b/tmk_core/protocol/ibmpc.cpp
@@ -402,7 +402,7 @@ NEXT:
 }
 
 /* send enquiry byte to keyboard to check if it can handle LED state byte */
-bool IBMPC::host_enq_led(void)
+bool IBMPC::host_led_enq(void)
 {
     return (host_send(IBMPC_SET_LED) == IBMPC_ACK);
 }

--- a/tmk_core/protocol/ibmpc.hpp
+++ b/tmk_core/protocol/ibmpc.hpp
@@ -110,7 +110,7 @@ class IBMPC
     int16_t host_recv_response(void);
     int16_t host_recv(void);
     void host_isr_clear(void);
-    bool host_enq_led(void);
+    bool host_led_enq(void);
     void host_set_led(uint8_t led);
 
     IBMPC(uint8_t clock, uint8_t data) :

--- a/tmk_core/protocol/ibmpc.hpp
+++ b/tmk_core/protocol/ibmpc.hpp
@@ -110,6 +110,7 @@ class IBMPC
     int16_t host_recv_response(void);
     int16_t host_recv(void);
     void host_isr_clear(void);
+    bool host_enq_led(void);
     void host_set_led(uint8_t led);
 
     IBMPC(uint8_t clock, uint8_t data) :


### PR DESCRIPTION
Refactored LED indicator routine to incorporate updating LEDs on the converter itself (LEDs wired directly to controller pins) primarily for the sake of keyboards that speak unidirectional protocols and/or have no LED indicators on them. Still safeguards sending IBM-formatted LED control byte to "XT" protocol keyboards or anything that has not yet been identified, just does it in a different place to facilitate controlling the LEDs on the converter.

If there are any issues with the way I've structured the converter LED part, I have a separate branch on which I just refactored the existing routine to make it slightly more efficient (specifically, it now only converts the USB HID format LED control byte to IBM format if it's already determined that it will be sending it to the keyboard, whereas before it did the translation anyway and could then decide afterwards that it was not going to be used).

Note: Mousekeys disabled by default because even when using avr-gcc 5.4 or 5.5, I cannot get TMK to compile either on Ubuntu 20.04 LTS or on macOS with Mousekeys disabled (not just because of my changes, but also from master branch).